### PR TITLE
Reorganize ATEX blog to root directory

### DIFF
--- a/.nojekyll
+++ b/.nojekyll
@@ -1,0 +1,1 @@
+# Disable Jekyll processing for docs deployment

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# ATEXpert – statyczna baza wiedzy ATEX
+
+Projekt zawiera statyczną aplikację blogową poświęconą bezpieczeństwu przeciwwybuchowemu. Wszystkie pliki serwisu znajdują się w katalogu głównym repozytorium, dzięki czemu witrynę można publikować bezpośrednio z gałęzi `main` w GitHub Pages.
+
+## Uruchomienie lokalne
+
+```bash
+python -m http.server 8000
+```
+
+Po uruchomieniu wejdź na `http://localhost:8000/`, aby zobaczyć stronę główną. Podstrony `category.html` oraz `post.html` korzystają z tych samych zasobów (stylów i skryptów), więc będą działać automatycznie.
+
+## Struktura katalogów
+
+- `index.html` – strona główna z kafelkami sekcji, blokiem kontaktowym i grą edukacyjną.
+- `category.html` – lista tematów wybranej sekcji.
+- `post.html` – renderer pojedynczego artykułu.
+- `scripts/` – logika interfejsu oraz zestaw danych udostępniany jako `window.ATEX_DATA`.
+- `styles/` – arkusze stylów witryny.
+- `images/` – grafiki używane w sekcji hero i elementach dekoracyjnych.
+- `.nojekyll` – plik wyłączający przetwarzanie Jekylla w GitHub Pages.
+
+Całość działa jako aplikacja typu SPA z prostym routowaniem parametrami zapytania, dzięki czemu nie jest wymagane żadne środowisko wykonawcze po stronie serwera.

--- a/category.html
+++ b/category.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html lang="pl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>ATEXpert – tematy kategorii</title>
+    <meta
+      name="description"
+      content="Lista tematów ATEX pogrupowanych w kategoriach. Wybierz zagadnienie, aby przejść do artykułu przygotowanego przez ekspertów."
+    />
+    <link rel="stylesheet" href="styles/main.css" />
+  </head>
+  <body>
+    <a class="skip-link" href="#lista-tematow">Przejdź do listy tematów</a>
+    <nav class="navbar">
+      <div class="nav-container">
+        <a href="index.html" class="logo">ATEXpert</a>
+        <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="menu">Menu</button>
+        <div class="nav-links" id="menu">
+          <a href="index.html#sekcje">Sekcje</a>
+          <a href="index.html#gra">Gra Ex</a>
+          <a href="#kontakt">Kontakt</a>
+        </div>
+      </div>
+    </nav>
+
+    <header class="hero hero--compact">
+      <div class="wrap hero-inner">
+        <div class="hero-copy">
+          <h1 data-category-title>Tematy kategorii</h1>
+          <p class="intro-text" data-category-description>
+            Wczytywanie informacji o kategorii. Za chwilę wyświetlimy listę tematów.
+          </p>
+          <div class="cta-group">
+            <a class="secondary" href="index.html">Wróć do strony głównej</a>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <main class="wrap section" id="lista-tematow">
+      <div class="topics-list" data-topic-list></div>
+    </main>
+
+    <footer class="footer" id="kontakt">
+      <div class="wrap footer-inner">
+        <div>
+          <strong>ATEXpert</strong> – szkolenia, audyty i wsparcie projektowe dla stref Ex.
+        </div>
+        <div class="footer-contact">
+          <a href="mailto:lyzwinski.biznes@gmail.com">lyzwinski.biznes@gmail.com</a>
+          <a href="tel:+48796465503">+48&nbsp;796&nbsp;465&nbsp;503</a>
+        </div>
+        <div class="footer-nav">
+          <a href="index.html#sekcje">Sekcje</a>
+          <a href="index.html#gra">Gra Ex</a>
+          <a href="index.html#o-nas">O nas</a>
+        </div>
+        <div class="footer-meta">© <span data-year></span> ATEXpert. Wszystkie prawa zastrzeżone.</div>
+      </div>
+    </footer>
+
+    <noscript>
+      <div class="noscript">
+        <p>Ta strona wymaga JavaScript do wyświetlenia listy tematów. Włącz obsługę skryptów w przeglądarce.</p>
+      </div>
+    </noscript>
+
+    <script src="scripts/data.js" defer></script>
+    <script src="scripts/category.js" defer></script>
+  </body>
+</html>

--- a/images/hero-pattern.svg
+++ b/images/hero-pattern.svg
@@ -1,0 +1,19 @@
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Stylizowane tło z siatką i falami">
+  <defs>
+    <linearGradient id="g1" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0B5C5E" />
+      <stop offset="100%" stop-color="#0E2A47" />
+    </linearGradient>
+    <linearGradient id="g2" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.08)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+    <pattern id="grid" width="80" height="80" patternUnits="userSpaceOnUse">
+      <path d="M80 0H0V80" fill="none" stroke="rgba(255,255,255,0.08)" stroke-width="1" />
+    </pattern>
+  </defs>
+  <rect width="1600" height="900" fill="url(#g1)" />
+  <rect width="1600" height="900" fill="url(#grid)" />
+  <path d="M-50 680 Q400 560 820 720 T1650 660 V950 H-50Z" fill="url(#g2)" />
+  <path d="M-120 520 Q420 420 860 560 T1700 520 V950 H-120Z" fill="rgba(255,255,255,0.07)" />
+</svg>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,140 @@
+<!doctype html>
+<html lang="pl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>ATEXpert – Kompendium wiedzy o bezpieczeństwie przeciwwybuchowym</title>
+    <meta
+      name="description"
+      content="Sekcje wiedzy ATEX, interaktywna gra doboru urządzeń i komplet artykułów o iskrobezpieczeństwie przygotowane przez ekspertów."
+    />
+    <link rel="stylesheet" href="styles/main.css" />
+  </head>
+  <body>
+    <a class="skip-link" href="#sekcje">Przejdź do listy sekcji</a>
+    <nav class="navbar">
+      <div class="nav-container">
+        <a href="index.html" class="logo" aria-label="ATEXpert – strona główna">ATEXpert</a>
+        <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="menu">Menu</button>
+        <div class="nav-links" id="menu">
+          <a href="#sekcje">Sekcje</a>
+          <a href="#gra">Gra Ex</a>
+          <a href="#kontakt">Kontakt</a>
+        </div>
+      </div>
+    </nav>
+
+    <header class="hero" role="banner">
+      <div class="wrap hero-inner">
+        <div class="hero-copy">
+          <p class="badge">Eksperci ATEX z 20-letnim doświadczeniem</p>
+          <h1>Kompendium Wiedzy ATEX</h1>
+          <p class="intro-text">
+            Wszystkie kluczowe zagadnienia o bezpieczeństwie przeciwwybuchowym zebrane w jednym miejscu. Od podstaw i
+            wymagań prawnych, przez dobór aparatury i utrzymanie ruchu, aż po case studies oraz nowoczesne technologie.
+          </p>
+          <div class="cta-group">
+            <a class="primary" href="#sekcje">Poznaj sekcje</a>
+            <a class="secondary" href="#gra">Zagraj w quiz Ex</a>
+          </div>
+        </div>
+        <div class="hero-highlight" aria-hidden="true">
+          <span>ATEX</span>
+          <span>IECEx</span>
+          <span>Iskrobezpieczeństwo</span>
+        </div>
+      </div>
+    </header>
+
+    <main>
+      <section class="wrap section" id="sekcje" aria-labelledby="sekcje-heading">
+        <div class="section-heading">
+          <h2 id="sekcje-heading">Sekcje bazy wiedzy</h2>
+          <p>Wybierz obszar, a następnie przejdź do wszystkich tematów i artykułów w danej kategorii.</p>
+        </div>
+        <div class="category-grid" data-category-grid></div>
+      </section>
+
+      <section class="wrap about section" id="o-nas" aria-labelledby="o-nas-heading">
+        <div class="about-copy">
+          <h2 id="o-nas-heading">Dlaczego ATEXpert?</h2>
+          <p>
+            Zespół ATEXpert łączy doświadczenie projektowe, audytowe i szkoleniowe. Tworzymy dokumentację DTR i DoC,
+            prowadzimy audyty ATEX 153, a także wspieramy działy utrzymania ruchu w ocenie instalacji Ex. Ta baza wiedzy
+            gromadzi praktyczne notatki, listy kontrolne oraz przykłady zaczerpnięte z realnych wdrożeń.
+          </p>
+        </div>
+        <div class="about-card">
+          <h3>Masz pytania?</h3>
+          <p>Napisz do nas lub zadzwoń – odpowiemy w ciągu 24 godzin roboczych.</p>
+          <a class="contact-link" href="mailto:lyzwinski.biznes@gmail.com">lyzwinski.biznes@gmail.com</a>
+          <a class="contact-link" href="tel:+48796465503">+48&nbsp;796&nbsp;465&nbsp;503</a>
+        </div>
+      </section>
+
+      <section class="wrap section game" id="gra" aria-labelledby="gra-heading">
+        <div class="section-heading">
+          <h2 id="gra-heading">Gra: dobierz urządzenie do strefy Ex</h2>
+          <p>
+            Sprawdź swoją wiedzę projektową. W każdym pytaniu dobierz właściwe urządzenie do opisanej strefy Ex, zgodnie z
+            zasadami iskrobezpieczeństwa i ochrony przeciwwybuchowej.
+          </p>
+        </div>
+        <div class="game-container" data-game>
+          <div class="game-status">
+            <p><strong>Wynik:</strong> <span data-score>0</span> / <span data-round>0</span></p>
+            <p data-feedback>Wybierz odpowiedź, aby rozpocząć.</p>
+            <div class="game-buttons">
+              <button type="button" class="primary" data-next>Losuj pytanie</button>
+              <button type="button" class="secondary" data-reset>Resetuj grę</button>
+            </div>
+          </div>
+          <div class="game-question">
+            <h3 data-scenario-heading>Przykładowy scenariusz</h3>
+            <p data-scenario-description>Wylosuj pytanie, aby rozpocząć rozgrywkę.</p>
+            <ul class="game-options" data-options></ul>
+          </div>
+          <aside class="game-rules">
+            <h3>Zasady</h3>
+            <ol>
+              <li>W każdej rundzie losujemy scenariusz strefy zagrożonej wybuchem.</li>
+              <li>Wybierz urządzenie, które spełnia wymagania danej strefy oraz kategorii sprzętu.</li>
+              <li>Po udzieleniu odpowiedzi otrzymasz komentarz i przechodzisz do kolejnego pytania.</li>
+              <li>Możesz zresetować grę, aby rozpocząć od nowa i poprawić wynik.</li>
+            </ol>
+          </aside>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer" id="kontakt">
+      <div class="wrap footer-inner">
+        <div>
+          <strong>ATEXpert</strong> – szkolenia, audyty i wsparcie projektowe dla stref Ex.
+        </div>
+        <div class="footer-contact">
+          <a href="mailto:lyzwinski.biznes@gmail.com">lyzwinski.biznes@gmail.com</a>
+          <a href="tel:+48796465503">+48&nbsp;796&nbsp;465&nbsp;503</a>
+        </div>
+        <div class="footer-nav">
+          <a href="#sekcje">Sekcje</a>
+          <a href="#gra">Gra Ex</a>
+          <a href="#o-nas">O nas</a>
+        </div>
+        <div class="footer-meta">© <span data-year></span> ATEXpert. Wszystkie prawa zastrzeżone.</div>
+      </div>
+    </footer>
+
+    <noscript>
+      <div class="noscript">
+        <p>
+          Strona korzysta z JavaScript do generowania listy sekcji oraz działania gry edukacyjnej. Włącz obsługę
+          skryptów, aby zobaczyć pełną zawartość.
+        </p>
+      </div>
+    </noscript>
+
+    <script src="scripts/data.js" defer></script>
+    <script src="scripts/index.js" defer></script>
+  </body>
+</html>

--- a/post.html
+++ b/post.html
@@ -1,0 +1,87 @@
+<!doctype html>
+<html lang="pl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>ATEXpert – artykuł</title>
+    <meta
+      name="description"
+      content="Artykuły ATEXpert dotyczące dyrektyw ATEX, iskrobezpieczeństwa i utrzymania ruchu w strefach zagrożonych wybuchem."
+    />
+    <link rel="stylesheet" href="styles/main.css" />
+  </head>
+  <body>
+    <a class="skip-link" href="#tresc">Przejdź do treści artykułu</a>
+    <nav class="navbar">
+      <div class="nav-container">
+        <a href="index.html" class="logo">ATEXpert</a>
+        <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="menu">Menu</button>
+        <div class="nav-links" id="menu">
+          <a data-breadcrumb-main href="index.html#sekcje">Sekcje</a>
+          <a href="index.html#gra">Gra Ex</a>
+          <a href="#kontakt">Kontakt</a>
+        </div>
+      </div>
+    </nav>
+
+    <header class="hero hero--compact">
+      <div class="wrap hero-inner">
+        <div class="hero-copy">
+          <p class="badge" data-category-pill>ATEXpert</p>
+          <h1 data-hero-heading>Ładowanie artykułu…</h1>
+          <p class="intro-text" data-hero-lead>
+            Zobacz szczegółowe opracowanie przygotowane przez ekspertów ATEXpert. Sprawdź wskazówki, checklisty i
+            obliczenia dla stref zagrożonych wybuchem.
+          </p>
+          <div class="cta-group">
+            <a class="secondary" data-back-to-category href="index.html">Wróć do sekcji</a>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <main class="wrap section article-wrap" id="tresc">
+      <a class="back-link" data-breadcrumb-category href="index.html">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <polyline points="15 18 9 12 15 6"></polyline>
+        </svg>
+        Wróć do listy tematów
+      </a>
+
+      <article class="article" data-article>
+        <h1 id="article-title">Ładujemy treść…</h1>
+        <div class="article-meta" data-article-meta>Opracowanie ATEXpert</div>
+        <div class="article-content" data-article-content>
+          <p>Chwilka cierpliwości – za moment wyświetlimy pełną treść artykułu.</p>
+        </div>
+      </article>
+    </main>
+
+    <footer class="footer" id="kontakt">
+      <div class="wrap footer-inner">
+        <div>
+          <strong>ATEXpert</strong> – szkolenia, audyty i wsparcie projektowe dla stref Ex.
+        </div>
+        <div class="footer-contact">
+          <a href="mailto:lyzwinski.biznes@gmail.com">lyzwinski.biznes@gmail.com</a>
+          <a href="tel:+48796465503">+48&nbsp;796&nbsp;465&nbsp;503</a>
+        </div>
+        <div class="footer-nav">
+          <a href="index.html#sekcje">Sekcje</a>
+          <a href="index.html#gra">Gra Ex</a>
+          <a href="index.html#o-nas">O nas</a>
+        </div>
+        <div class="footer-meta">© <span data-year></span> ATEXpert. Wszystkie prawa zastrzeżone.</div>
+      </div>
+    </footer>
+
+    <noscript>
+      <div class="noscript">
+        <p>Artykuł wymaga JavaScript, aby wczytać treść oraz nawigację. Włącz obsługę skryptów.</p>
+      </div>
+    </noscript>
+
+    <script src="scripts/data.js" defer></script>
+    <script src="scripts/post.js" defer></script>
+  </body>
+</html>

--- a/scripts/category.js
+++ b/scripts/category.js
@@ -1,0 +1,100 @@
+let categories = [];
+
+document.addEventListener('DOMContentLoaded', () => {
+  const data = window.ATEX_DATA || {};
+  categories = Array.isArray(data.categories) ? data.categories : [];
+
+  initNavigation();
+  renderCategory();
+  setCurrentYear();
+});
+
+function initNavigation() {
+  const toggle = document.querySelector('.nav-toggle');
+  const menu = document.querySelector('.nav-links');
+
+  if (!toggle || !menu) return;
+
+  toggle.addEventListener('click', () => {
+    const expanded = toggle.getAttribute('aria-expanded') === 'true';
+    toggle.setAttribute('aria-expanded', String(!expanded));
+    menu.classList.toggle('nav-links--open');
+  });
+
+  menu.querySelectorAll('a').forEach((link) => {
+    link.addEventListener('click', () => {
+      toggle.setAttribute('aria-expanded', 'false');
+      menu.classList.remove('nav-links--open');
+    });
+  });
+}
+
+function renderCategory() {
+  const params = new URLSearchParams(window.location.search);
+  const categoryId = params.get('category');
+  const container = document.querySelector('[data-topic-list]');
+  const heading = document.querySelector('[data-category-title]');
+  const description = document.querySelector('[data-category-description]');
+
+  if (!container || !heading || !description) return;
+
+  if (!categoryId) {
+    renderError(container, 'Nie znaleziono wskazanej kategorii. Wróć do strony głównej, aby wybrać sekcję.');
+    return;
+  }
+
+  const category = categories.find((item) => item.id === categoryId);
+
+  if (!category) {
+    renderError(container, 'Wybrana kategoria została przeniesiona lub nie istnieje.');
+    return;
+  }
+
+  document.title = `${category.title} – ATEXpert`;
+  heading.textContent = category.title;
+  description.textContent = category.description;
+
+  container.innerHTML = '';
+
+  category.posts.forEach((post) => {
+    const article = document.createElement('article');
+    article.className = 'topic-item';
+
+    const title = document.createElement('h2');
+    const link = document.createElement('a');
+    link.href = `post.html?slug=${encodeURIComponent(post.slug)}&category=${encodeURIComponent(category.id)}`;
+    link.textContent = post.title;
+    title.append(link);
+
+    const meta = document.createElement('p');
+    meta.className = 'topic-item__meta';
+    if (post.readTime) {
+      meta.textContent = `Szacowany czas czytania: ${post.readTime}`;
+    }
+
+    const summary = document.createElement('p');
+    summary.textContent = post.summary;
+
+    article.append(title, meta, summary);
+    container.append(article);
+  });
+}
+
+function renderError(container, message) {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'empty-state';
+  wrapper.innerHTML = `
+    <h2>Ups! Nie ma takiej kategorii</h2>
+    <p>${message}</p>
+    <a class="secondary" href="index.html">Wróć do strony głównej</a>
+  `;
+
+  container.innerHTML = '';
+  container.append(wrapper);
+}
+
+function setCurrentYear() {
+  document.querySelectorAll('[data-year]').forEach((element) => {
+    element.textContent = String(new Date().getFullYear());
+  });
+}

--- a/scripts/data.js
+++ b/scripts/data.js
@@ -1,0 +1,1262 @@
+// Zestaw danych dla bazy wiedzy ATEXpert.
+// Każda kategoria zawiera listę postów z treścią przygotowaną przez zespół ekspertów.
+
+const categories = [
+  {
+    id: 'podstawy-ex',
+    title: '1. Podstawy EX i ATEX',
+    description:
+      'Wprowadzenie dla każdego nowego czytelnika – solidna baza wiedzy i fundament pod SEO.',
+    posts: [
+      {
+        slug: 'co-to-jest-iskrobezpieczenstwo',
+        title: 'Co to jest iskrobezpieczeństwo (Ex i)?',
+        summary:
+          'Poznaj zasadę ograniczania energii w obwodach, dzięki której urządzenia pozostają bezpieczne nawet przy zwarciu.',
+        readTime: '6 min',
+        content: [
+          {
+            type: 'paragraph',
+            text: 'Iskrobezpieczeństwo – oznaczenie Ex i – to metoda ochrony przeciwwybuchowej, która polega na ograniczeniu energii dostępnej w obwodzie do poziomu nieskutkującego zapłonem mieszaniny wybuchowej. Bariery oraz zasilacze Ex i mają za zadanie ograniczyć prąd i napięcie do wartości dopuszczalnych przez normę PN-EN 60079-11.',
+          },
+          {
+            type: 'heading',
+            level: 3,
+            text: 'Kluczowe elementy systemu Ex i',
+          },
+          {
+            type: 'list',
+            ordered: false,
+            items: [
+              'Źródło zasilania z odpowiednią charakterystyką ograniczającą prąd i napięcie.',
+              'Ograniczenie pojemności i indukcyjności w przewodach oraz urządzeniach peryferyjnych.',
+              'Certyfikowane urządzenia końcowe – czujniki, przetworniki, pozycjonery – z określonymi parametrami wejściowymi.',
+            ],
+          },
+          {
+            type: 'paragraph',
+            text: 'Projektant systemu musi udokumentować zgodność układu, obliczyć margines bezpieczeństwa dla C i L oraz przygotować procedury eksploatacji. W zamian otrzymuje możliwość pracy i serwisowania instalacji bez konieczności wyłączania zasilania.',
+          },
+        ],
+      },
+      {
+        slug: 'podzial-stref-zagrozenia',
+        title: 'Podział stref zagrożenia wybuchem: 0/1/2 vs 20/21/22',
+        summary:
+          'Porównujemy strefy gazowe i pyłowe, wyjaśniając kategorie urządzeń i konsekwencje projektowe.',
+        readTime: '7 min',
+        content: [
+          {
+            type: 'paragraph',
+            text: 'Dyrektywa ATEX rozróżnia strefy zagrożenia dla gazów (0, 1, 2) oraz pyłów (20, 21, 22). O przynależności decyduje częstotliwość występowania atmosfery wybuchowej – od ciągłej (strefa 0/20) po sporadyczną (strefa 2/22).',
+          },
+          {
+            type: 'paragraph',
+            text: 'Dobór urządzeń powinien uwzględniać kategorię sprzętu: 1G/1D dla strefy 0/20, 2G/2D dla stref 1/21 oraz 3G/3D dla stref 2/22. Odmienne są także wymagania dotyczące dokumentacji, przeglądów i uziemienia instalacji.',
+          },
+          {
+            type: 'list',
+            ordered: true,
+            items: [
+              'Określ źródła emisji i kierunek wentylacji.',
+              'Przypisz strefę zgodnie z PN-EN 60079-10-1 (gazy) lub PN-EN 60079-10-2 (pyły).',
+              'Dobierz urządzenia o odpowiedniej kategorii i klasie temperaturowej.',
+            ],
+          },
+        ],
+      },
+      {
+        slug: 'rodzaje-ochrony-ex',
+        title: 'Rodzaje ochrony: Ex i, Ex d, Ex e, Ex nR itd.',
+        summary:
+          'Przegląd podstawowych typów zabezpieczeń wraz z zastosowaniami i ograniczeniami.',
+        readTime: '8 min',
+        content: [
+          {
+            type: 'paragraph',
+            text: 'Norma serii IEC 60079 opisuje kilkanaście sposobów zabezpieczenia urządzeń. Najpopularniejsze to: Ex d (ognioodporna obudowa), Ex e (zwiększone bezpieczeństwo), Ex n (urządzenia dla strefy 2), Ex t (ochrona pyłowa) oraz Ex i (iskrobezpieczeństwo).',
+          },
+          {
+            type: 'heading',
+            level: 3,
+            text: 'Dobór metody ochrony',
+          },
+          {
+            type: 'list',
+            ordered: false,
+            items: [
+              'Ex d sprawdza się w przypadku aparatury o wysokiej energii – silniki, rozruszniki, aparatura wysokoprądowa.',
+              'Ex e to rozwiązanie do rozdzielnic, zacisków i elementów, które nie powinny iskrzyć w normalnej pracy.',
+              'Ex nR to restricted breathing – ograniczenie wymiany gazów z otoczeniem, popularne w monitoringu drgań.',
+            ],
+          },
+          {
+            type: 'paragraph',
+            text: 'W praktyce jeden obiekt korzysta z wielu metod. Ważne jest, by zachować kompatybilność i udokumentować dobór w ocenie zagrożenia wybuchem.',
+          },
+        ],
+      },
+      {
+        slug: 'roznice-gas-vs-dust',
+        title: 'Różnice Gas vs Dust',
+        summary:
+          'Pyły i gazy zachowują się inaczej – zobacz jak wpływa to na projektowanie, detekcję i konserwację.',
+        readTime: '5 min',
+        content: [
+          {
+            type: 'paragraph',
+            text: 'Mieszaniny gazowe tworzą atmosferę wybuchową w całej objętości pomieszczenia, natomiast pyły osiadają na powierzchniach i tworzą chmury przy naruszeniu warstwy. Pyły przewodzą ciepło gorzej i mogą żarzyć się długo po zapłonie.',
+          },
+          {
+            type: 'paragraph',
+            text: 'Dla pyłów kluczowe jest ograniczenie temperatury powierzchni urządzeń oraz zapobieganie gromadzeniu się warstw. Dlatego norma PN-EN 60079-31 wprowadza limity dla grubości pyłu i temperatury T.',
+          },
+          {
+            type: 'list',
+            ordered: false,
+            items: [
+              'Oznaczenia EPL różnią się literą: Gb/Gc dla gazów oraz Db/Dc dla pyłów.',
+              'Urządzenia dla pyłów muszą być pyłoszczelne – IP6X to często za mało, wymagane są testy IEC.',
+              'Dla gazów większe znaczenie ma klasa temperaturowa T1–T6 i minimalna energia zapłonu.',
+            ],
+          },
+        ],
+      },
+      {
+        slug: 'mity-o-atex',
+        title: 'Mity o ATEX i iskrobezpieczeństwie – obalamy',
+        summary:
+          'Najczęściej spotykane przekonania na audytach ATEX i dlaczego mogą być niebezpieczne.',
+        readTime: '6 min',
+        content: [
+          {
+            type: 'paragraph',
+            text: 'Mit 1: „Wystarczy wysoki stopień IP”. Prawda: ochrona IP dotyczy jedynie pyłów i wody, a nie zapobiegania zapłonowi. Mit 2: „Każde urządzenie Ex pasuje wszędzie”. Tymczasem liczy się kategoria urządzenia, klasa temperaturowa oraz grupa wybuchowości.',
+          },
+          {
+            type: 'paragraph',
+            text: 'Mit 3: „Bariera jest potrzebna tylko przy długich kablach”. Bariera Ex i jest obowiązkowa zawsze, gdy urządzenie polowe ma certyfikat Ex ia/ib, niezależnie od długości przewodu. Błędne założenia skutkują brakiem zgodności i ryzykiem dla personelu.',
+          },
+          {
+            type: 'quote',
+            text: 'Kultura bezpieczeństwa zaczyna się od obalania mitów. Regularne szkolenia minimalizują liczbę błędów eksploatacyjnych.',
+          },
+        ],
+      },
+      {
+        slug: 'faq-ex',
+        title: 'FAQ: 10 najczęstszych pytań klientów o Ex',
+        summary:
+          'Zebraliśmy odpowiedzi na pytania, które pojawiają się podczas audytów, szkoleń i konsultacji technicznych.',
+        readTime: '9 min',
+        content: [
+          {
+            type: 'paragraph',
+            text: 'Jak dobrać dokumentację? Czy można łączyć certyfikaty ATEX i IECEx? Co z utylizacją urządzeń? Odpowiadamy na dziesięć pytań, które regularnie słyszymy w zakładach.',
+          },
+          {
+            type: 'list',
+            ordered: true,
+            items: [
+              'Czy znakowanie Ex jest obowiązkowe na każdej obudowie? – Tak, wraz z kategorią i numerem certyfikatu.',
+              'Czy można stosować sprzęt ATEX w strefie IECEx? – Tak, jeżeli wymagania EPL są spełnione i dokumentacja to potwierdza.',
+              'Jak długo przechowywać DTR? – Minimum 10 lat od wprowadzenia urządzenia do obrotu.',
+              'Czy zwykły laptop może wejść do strefy 2? – Tylko z odpowiednimi środkami kontroli atmosfery i procedurą zezwoleń.',
+            ],
+          },
+          {
+            type: 'paragraph',
+            text: 'Pełną listę odpowiedzi wraz z odniesieniami do norm znajdziesz w naszym arkuszu FAQ dostępnych materiałów.',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'prawo-i-cert',
+    title: '2. Prawo i Certyfikacja',
+    description:
+      'Regulacje, normy, zgodność i rola kluczowych instytucji w systemie ATEX.',
+    posts: [
+      {
+        slug: 'atex-114-vs-153',
+        title: 'ATEX 114 vs ATEX 153 – różnice i praktyka w Polsce',
+        summary:
+          'Porównanie obowiązków producentów i użytkowników końcowych wynikających z dwóch dyrektyw ATEX.',
+        readTime: '8 min',
+        content: [
+          {
+            type: 'paragraph',
+            text: 'ATEX 114 (2014/34/UE) dotyczy producentów, którzy wprowadzają sprzęt na rynek UE, natomiast ATEX 153 (1999/92/WE) określa obowiązki pracodawców i użytkowników instalacji. Obie dyrektywy wzajemnie się uzupełniają i wymagają spójnej dokumentacji.',
+          },
+          {
+            type: 'paragraph',
+            text: 'W Polsce implementację zapewnia rozporządzenie Ministra Rozwoju z 2016 r. oraz rozporządzenie w sprawie minimalnych wymagań BHP. W praktyce oznacza to, że producent przygotowuje dokumentację techniczną i deklarację zgodności, a użytkownik tworzy ocenę ryzyka i instrukcje eksploatacji.',
+          },
+          {
+            type: 'list',
+            ordered: false,
+            items: [
+              'ATEX 114 → certyfikacja jednostki notyfikowanej, moduły oceny zgodności, oznakowanie CE oraz Ex.',
+              'ATEX 153 → analiza ryzyka, klasyfikacja stref, szkolenia pracowników i plan awaryjny.',
+              'Wspólnym elementem są audyty UDT oraz kontrola dokumentacji przez służby BHP.',
+            ],
+          },
+        ],
+      },
+      {
+        slug: 'polskie-akty-prawne',
+        title: 'Polskie akty prawne i odniesienia do PN-EN/IEC 60079',
+        summary:
+          'Zestawienie najważniejszych przepisów krajowych, które regulują eksploatację urządzeń w strefach Ex.',
+        readTime: '7 min',
+        content: [
+          {
+            type: 'paragraph',
+            text: 'Poza dyrektywami unijnymi obowiązują krajowe akty prawne: Prawo energetyczne, ustawa o dozorze technicznym, rozporządzenia dotyczące BHP oraz transportu. Uzupełniają je Polskie Normy z serii PN-EN 60079 (identyczne z IEC 60079).',
+          },
+          {
+            type: 'paragraph',
+            text: 'Z praktycznego punktu widzenia warto opracować listę norm referencyjnych w dokumentacji zakładu: PN-EN 60079-0, -10-1, -10-2, -14, -17, -19 oraz -31. Pozwala to zminimalizować wątpliwości przy audytach UDT lub PCA.',
+          },
+          {
+            type: 'quote',
+            text: 'Aktualny wykaz norm można uzyskać w Polskim Komitecie Normalizacyjnym – pamiętaj, że odwołania w dokumentacji muszą wskazywać numer i rok wydania.',
+          },
+        ],
+      },
+      {
+        slug: 'rola-udt-pca',
+        title: 'Rola UDT i PCA w systemie ATEX',
+        summary:
+          'Wyjaśniamy kompetencje Urzędu Dozoru Technicznego i Polskiego Centrum Akredytacji w obszarze ATEX.',
+        readTime: '5 min',
+        content: [
+          {
+            type: 'paragraph',
+            text: 'UDT sprawuje nadzór nad eksploatacją urządzeń technicznych, w tym nad oceną zgodności instalacji w strefach Ex. PCA akredytuje laboratoria i jednostki certyfikujące, które przeprowadzają badania urządzeń oraz audyty systemów jakości.',
+          },
+          {
+            type: 'paragraph',
+            text: 'W praktyce oznacza to, że dokumenty wystawione przez jednostki bez akredytacji PCA mogą zostać zakwestionowane. Przy odbiorze instalacji należy przedstawić aktualne certyfikaty, raporty z badań oraz dowody kompetencji personelu.',
+          },
+          {
+            type: 'list',
+            ordered: false,
+            items: [
+              'UDT – kontrola urządzeń, zatwierdzanie dokumentacji, wydawanie decyzji zezwalających na eksploatację.',
+              'PCA – akredytacja laboratoriów badawczych, jednostek certyfikujących i inspekcyjnych.',
+              'Współpraca – audyty zintegrowane, wymiana informacji o niezgodnościach i zaleceniach pokontrolnych.',
+            ],
+          },
+        ],
+      },
+      {
+        slug: 'weryfikacja-certyfikatow-atex',
+        title: 'Jak weryfikować certyfikaty ATEX/IECEx (fake certyfikaty, checklista)',
+        summary:
+          'Procedura krok po kroku, która pozwala uniknąć podrobionych certyfikatów i wątpliwej dokumentacji.',
+        readTime: '6 min',
+        content: [
+          {
+            type: 'paragraph',
+            text: 'Fałszywe certyfikaty to realne ryzyko. Zawsze sprawdzaj numer jednostki notyfikowanej oraz podpisy elektroniczne. W przypadku systemu IECEx korzystaj z oficjalnej bazy danych (www.iecex.com).',
+          },
+          {
+            type: 'list',
+            ordered: true,
+            items: [
+              'Zweryfikuj, czy jednostka wydająca certyfikat figuruje na liście NANDO lub w bazie IECEx.',
+              'Porównaj dane identyfikacyjne urządzenia – model, parametry Ex, zakres temperatur – z tabliczką znamionową.',
+              'Skontroluj integralność dokumentu (pieczęcie, podpisy, kody QR) oraz aktualność rewizji.',
+            ],
+          },
+          {
+            type: 'paragraph',
+            text: 'W przypadku wątpliwości poproś producenta o raport z badań typu lub referencje z innych wdrożeń. Brak reakcji to sygnał ostrzegawczy.',
+          },
+        ],
+      },
+      {
+        slug: 'proces-certyfikacji-urzadzen',
+        title: 'Proces certyfikacji urządzeń krok po kroku',
+        summary:
+          'Od analizy ryzyka po znakowanie CE i Ex – opisujemy kolejne etapy przygotowania urządzenia na rynek.',
+        readTime: '9 min',
+        content: [
+          {
+            type: 'paragraph',
+            text: 'Producent rozpoczyna od analizy zagrożeń i określenia kategorii urządzenia. Następnie przygotowuje dokumentację techniczną, schematy, listy komponentów oraz wyniki badań. W zależności od modułu oceny zgodności (np. G, D, E) konieczne są badania typu i audyt systemu jakości.',
+          },
+          {
+            type: 'paragraph',
+            text: 'Po pozytywnej ocenie jednostki notyfikowanej producent wystawia deklarację zgodności UE, przygotowuje tabliczkę znamionową z oznaczeniem Ex oraz prowadzi archiwum dokumentacji przez minimum 10 lat.',
+          },
+          {
+            type: 'list',
+            ordered: true,
+            items: [
+              'Analiza ryzyka i określenie grupy oraz kategorii sprzętu.',
+              'Badania laboratoryjne i weryfikacja konstrukcji.',
+              'Audyt systemu jakości (moduł D/E), wydanie certyfikatu, znakowanie CE/Ex.',
+            ],
+          },
+        ],
+      },
+      {
+        slug: 'lifecycle-dokumentacji',
+        title: 'Lifecycle dokumentacji: jak tworzyć i utrzymywać DTR/DoC przez 10 lat',
+        summary:
+          'Praktyczne wskazówki dotyczące archiwizacji i aktualizacji dokumentacji technicznej urządzeń Ex.',
+        readTime: '6 min',
+        content: [
+          {
+            type: 'paragraph',
+            text: 'Deklaracja zgodności (DoC) oraz dokumentacja techniczno-ruchowa (DTR) muszą być przechowywane co najmniej 10 lat. Dokumenty należy aktualizować przy każdej zmianie konstrukcji lub norm referencyjnych. Warto wdrożyć system zarządzania dokumentacją z kontrolą wersji.',
+          },
+          {
+            type: 'paragraph',
+            text: 'W zakładach przemysłowych dobrą praktyką jest prowadzenie repozytorium elektronicznego z kopią offline. Dzięki temu audytorzy UDT lub PCA szybko weryfikują zgodność.',
+          },
+          {
+            type: 'list',
+            ordered: false,
+            items: [
+              'Wyznacz właściciela dokumentacji – zwykle dział konstrukcyjny lub jakości.',
+              'Stosuj oznaczenia rewizji i log zmian.',
+              'Zapewnij bezpieczne przechowywanie oryginałów oraz kopii cyfrowych.',
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'dowodzenie-iskrobezpieczenstwa',
+    title: '3. Dowodzenie Iskrobezpieczeństwa (Ex i)',
+    description:
+      'Najbardziej eksperckie treści, które wyróżniają bloga na tle konkurencji.',
+    posts: [
+      {
+        slug: 'parametry-co-li',
+        title: 'Parametry C₀/L₀ vs Cᵢ/Lᵢ – jak je rozumieć',
+        summary:
+          'Tłumaczymy, jak interpretować dane z barier Ex i i urządzeń polowych, aby zachować margines bezpieczeństwa.',
+        readTime: '7 min',
+        content: [
+          {
+            type: 'paragraph',
+            text: 'Parametry C₀ i L₀ określają maksymalną pojemność oraz indukcyjność, jaką bariera Ex i może obsłużyć po stronie strefy zagrożonej. Cᵢ i Lᵢ pochodzą z karty katalogowej urządzenia polowego. Suma pojemności i indukcyjności przewodów, czujnika i akcesoriów nie może przekroczyć C₀/L₀.',
+          },
+          {
+            type: 'paragraph',
+            text: 'Pamiętaj o dodatkowych elementach biernych – iskiernikach, filtrach EMC czy rezystorach terminujących. Zawsze dodawaj 10–20% marginesu na niepewność danych katalogowych.',
+          },
+          {
+            type: 'list',
+            ordered: false,
+            items: [
+              'Używaj arkuszy kalkulacyjnych producentów barier, aby uniknąć błędów arytmetycznych.',
+              'Zwracaj uwagę na temperaturę pracy – parametry C₀/L₀ mogą się zmieniać.',
+              'Dokumentuj każdy obwód w raporcie z dowodzenia iskrobezpieczeństwa.',
+            ],
+          },
+        ],
+      },
+      {
+        slug: 'entity-parameters',
+        title: 'Jak czytać entity parameters na tabliczce znamionowej',
+        summary:
+          'Krok po kroku analizujemy oznaczenia Ui, Ii, Pi oraz Ci/Li, aby uniknąć niezgodności.',
+        readTime: '5 min',
+        content: [
+          {
+            type: 'paragraph',
+            text: 'Entity parameters określają dopuszczalne wartości napięcia, prądu i mocy dostarczanej do urządzenia. Ich poprawna interpretacja jest warunkiem zgodności systemu Ex i. Na tabliczce znajdziesz symbole Ui, Ii, Pi, Ci oraz Li.',
+          },
+          {
+            type: 'paragraph',
+            text: 'Jeśli bariera dostarcza energię większą niż dopuszczalna (np. Ui > Uo bariery), konieczna jest inna konfiguracja lub element pośredni. Pamiętaj, że parametry dotyczą temperatury referencyjnej – przy -40 °C lub +60 °C mogą obowiązywać dodatkowe ograniczenia.',
+          },
+          {
+            type: 'list',
+            ordered: false,
+            items: [
+              'Sprawdź grupę wybuchowości (IIC, IIB, IIA) – wpływa na dopuszczalne wartości.',
+              'Zweryfikuj klasę temperaturową (T1–T6) oraz dopuszczalną temperaturę otoczenia.',
+              'Notuj dane w karcie obwodu – przyda się przy audycie i serwisie.',
+            ],
+          },
+        ],
+      },
+      {
+        slug: 'typowe-bledy-dowodzenie',
+        title: 'Typowe błędy w dowodzeniu (z przykładami schematów)',
+        summary:
+          'Na podstawie audytów pokazujemy najczęstsze niezgodności i sposoby ich eliminacji.',
+        readTime: '8 min',
+        content: [
+          {
+            type: 'paragraph',
+            text: 'Najczęstszy błąd to brak rozdzielenia przewodów Ex i od obwodów nieiskrobezpiecznych – nawet przy zachowaniu izolacji fizycznej. Kolejnym problemem jest łączenie kilku urządzeń z jedną barierą bez ponownej weryfikacji parametrów.',
+          },
+          {
+            type: 'paragraph',
+            text: 'Na schematach często pomija się rezystory końcowe, co zaniża obliczeniowe wartości C i L. Błąd ten wychodzi na jaw dopiero podczas inspekcji, gdy w obwodzie pojawia się dodatkowe urządzenie serwisowe.',
+          },
+          {
+            type: 'list',
+            ordered: true,
+            items: [
+              'Prowadź rejestr zmian schematów wraz z datą i podpisem odpowiedzialnego inżyniera.',
+              'Weryfikuj wszystkie dane w arkuszu kalkulacyjnym i załącz do raportu.',
+              'Stosuj system etykietowania przewodów, aby nie pomylić par podczas modernizacji.',
+            ],
+          },
+        ],
+      },
+      {
+        slug: 'przykladowe-obliczenia-exi',
+        title: 'Przykładowe obliczenia z XLS (casebook)',
+        summary:
+          'Udostępniamy przykładowy arkusz kalkulacyjny z trzema typowymi aplikacjami i kompletem wzorów.',
+        readTime: '7 min',
+        content: [
+          {
+            type: 'paragraph',
+            text: 'Casebook obejmuje obwód czujnika temperatury Pt100, przepływomierza magnetycznego oraz nadajnika poziomu radarowego. W każdym przypadku pokazujemy sposób sumowania pojemności przewodu, czujnika i dodatkowych elementów biernych.',
+          },
+          {
+            type: 'paragraph',
+            text: 'Arkusz XLS zawiera zakładki do obliczeń i porównania z parametrami barier. W artykule omawiamy także sposób walidacji wyników poprzez równoległe obliczenia ręczne.',
+          },
+          {
+            type: 'quote',
+            text: 'Niezależna walidacja danych minimalizuje ryzyko błędów, dlatego arkusz zawiera wbudowane ostrzeżenia przy zbliżaniu się do limitów C₀/L₀.',
+          },
+        ],
+      },
+      {
+        slug: 'mapa-bledow-projektowych',
+        title: '„Mapa błędów projektowych”: Top 5 błędów w schematach Ex',
+        summary:
+          'Wizualne zestawienie błędów, które powtarzają się na audytach w zakładach chemicznych i spożywczych.',
+        readTime: '6 min',
+        content: [
+          {
+            type: 'paragraph',
+            text: 'Mapa błędów pokazuje m.in. brak izolacji przewodów, łączenie ekranów po obu stronach, niewłaściwe uziemienie barier oraz mieszanie urządzeń Ex ia i Ex ib w jednym obwodzie. Każdy przypadek opisujemy w formie krótkiego studium wraz z zalecaną korektą.',
+          },
+          {
+            type: 'list',
+            ordered: false,
+            items: [
+              'Błąd 1 – brak rozdzielenia zacisków Ex i od obwodów standardowych.',
+              'Błąd 2 – stosowanie barier z niewystarczającą mocą wyjściową.',
+              'Błąd 3 – brak aktualizacji dokumentacji po modernizacji.',
+              'Błąd 4 – niewłaściwa klasa temperaturowa czujnika.',
+              'Błąd 5 – brak testów ciągłości uziemienia.',
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'urzadzenia-bariery',
+    title: '4. Urządzenia, Bariery, Technologie',
+    description: 'Praktyczny przewodnik dla inżyniera, projektanta i automatyka.',
+    posts: [
+      {
+        slug: 'bariery-vs-zasilacze',
+        title: 'Bariery galwaniczne vs zasilacze Ex i',
+        summary:
+          'Porównanie kosztów, łatwości instalacji i poziomu bezpieczeństwa w zależności od aplikacji.',
+        readTime: '6 min',
+        content: [
+          {
+            type: 'paragraph',
+            text: 'Bariery galwaniczne zapewniają pełną separację obwodów, eliminując konieczność uziemienia po stronie bezpiecznej. Zasilacze Ex i (tzw. izolatory zasilające) są bardziej kompaktowe i opłacalne przy wielu kanałach, lecz wymagają kontrolowanego punktu uziemienia.',
+          },
+          {
+            type: 'list',
+            ordered: false,
+            items: [
+              'Bariery galwaniczne – najwyższy poziom bezpieczeństwa, idealne dla sygnałów analogowych o wysokiej dokładności.',
+              'Zasilacze Ex i – dobra opcja dla czujników 2-przewodowych oraz sygnałów HART.',
+              'Rozwiązania hybrydowe – łączenie obu technologii w zależności od krytyczności sygnału.',
+            ],
+          },
+          {
+            type: 'paragraph',
+            text: 'Dobór rozwiązania powinien uwzględniać całkowity koszt posiadania – również serwis, moduły redundantne oraz miejsce w szafie sterowniczej.',
+          },
+        ],
+      },
+      {
+        slug: 'dobor-bariery',
+        title: 'Jak dobrać barierę do czujnika/pozycjonera',
+        summary:
+          'Instrukcja doboru krok po kroku wraz z checklistą parametrów i najczęstszymi pułapkami.',
+        readTime: '7 min',
+        content: [
+          {
+            type: 'paragraph',
+            text: 'Analizę rozpoczynamy od ustalenia typu sygnału (4–20 mA, NAMUR, HART) oraz wymaganej liczby przewodów. Następnie dobieramy barierę pod kątem Ui, Ii, Pi oraz dopuszczalnej rezystancji obciążenia.',
+          },
+          {
+            type: 'list',
+            ordered: true,
+            items: [
+              'Sprawdź wymagania funkcjonalne czujnika (np. prąd startu, minimalne napięcie).',
+              'Zweryfikuj parametry Ex bariery oraz grupę wybuchowości.',
+              'Dobierz akcesoria: bezpieczniki, listwy rozdzielcze, moduły diagnostyczne.',
+            ],
+          },
+          {
+            type: 'paragraph',
+            text: 'Checklistę doboru udostępniamy w sekcji materiałów do pobrania – warto ją wypełniać dla każdego obwodu.',
+          },
+        ],
+      },
+      {
+        slug: 'porownanie-dostawcow-barier',
+        title: 'Porównanie dostawców barier (P+F, R.STAHL, MTL itd.)',
+        summary:
+          'Analizujemy funkcje diagnostyczne, dostępność modułów redundantnych oraz wsparcie producentów.',
+        readTime: '8 min',
+        content: [
+          {
+            type: 'paragraph',
+            text: 'Pepperl+Fuchs, R.STAHL i MTL (Eaton) to najpopularniejsi dostawcy barier. Różnice dotyczą m.in. sposobu montażu (na szynie DIN lub w systemach szafowych), wsparcia dla protokołów HART oraz dostępności modułów redundancji.',
+          },
+          {
+            type: 'paragraph',
+            text: 'W artykule przedstawiamy tabelę porównawczą z parametrami elektrycznymi, funkcjami diagnostycznymi oraz dostępnością lokalnego serwisu. Omawiamy też koszty cyklu życia – wymianę modułów, aktualizacje firmware i wsparcie posprzedażowe.',
+          },
+          {
+            type: 'quote',
+            text: 'Przy wyborze dostawcy liczy się nie tylko cena zakupu, ale również dostępność wsparcia technicznego i gwarancji rozszerzonej.',
+          },
+        ],
+      },
+      {
+        slug: 'lifecycle-urzadzen-ex',
+        title: 'Lifecycle urządzeń Ex: od zakupu do dekomisji',
+        summary:
+          'Opisujemy etapy życia urządzenia w strefie Ex – od kwalifikacji dostawcy po utylizację.',
+        readTime: '6 min',
+        content: [
+          {
+            type: 'paragraph',
+            text: 'Lifecycle zaczyna się od oceny ryzyka i specyfikacji technicznej. Następnie realizujemy odbiór dostaw, montaż, uruchomienie, eksploatację, modernizacje i finalnie dekomisję. Każdy etap wymaga dokumentacji i przeglądów zgodnie z PN-EN 60079-17.',
+          },
+          {
+            type: 'list',
+            ordered: false,
+            items: [
+              'Odbiór dostawy – kontrola tabliczki znamionowej, zgodności z zamówieniem i integralności dokumentów.',
+              'Eksploatacja – harmonogram przeglądów, archiwizacja raportów, szkolenia personelu.',
+              'Dekomisja – usunięcie oznakowania Ex, czyszczenie urządzenia i utylizacja komponentów.',
+            ],
+          },
+        ],
+      },
+      {
+        slug: 'dlaczego-urzadzenie-ex-drozsze',
+        title: 'Porównania Ex vs non-Ex: dlaczego urządzenie Ex kosztuje kilka razy więcej?',
+        summary:
+          'Analiza kosztów konstrukcji, testów i certyfikacji, które wpływają na cenę urządzeń Ex.',
+        readTime: '5 min',
+        content: [
+          {
+            type: 'paragraph',
+            text: 'Urządzenie Ex wymaga specjalistycznych materiałów (np. iskrobezpieczne złącza, uszczelnienia), badań typu, audytów jakości oraz dodatkowej dokumentacji. Producent ponosi koszty utrzymania certyfikacji i monitorowania zmian w normach.',
+          },
+          {
+            type: 'paragraph',
+            text: 'Dzięki temu użytkownik otrzymuje produkt o wyższej niezawodności i mniejszym ryzyku przestojów. W artykule pokazujemy przykładową analizę TCO porównującą urządzenie Ex z wersją standardową.',
+          },
+          {
+            type: 'list',
+            ordered: false,
+            items: [
+              'Koszty projektowe i prototypowanie z udziałem jednostek certyfikujących.',
+              'Dodatkowe testy środowiskowe i wibracyjne.',
+              'Odpowiedzialność prawna producenta oraz gwarancje rozszerzone.',
+            ],
+          },
+        ],
+      },
+      {
+        slug: 'ex-nr-w-praktyce',
+        title: 'Ex nR w praktyce – kiedy restricted breathing ratuje projekt',
+        summary:
+          'Przykłady zastosowań urządzeń Ex nR w modernizacjach i szybkim retroficie instalacji.',
+        readTime: '6 min',
+        content: [
+          {
+            type: 'paragraph',
+            text: 'Ex nR ogranicza wymianę gazów z otoczeniem, co zapobiega przedostaniu się mieszaniny wybuchowej do wnętrza obudowy. Sprawdza się przy obudowach analizatorów, modułów komunikacyjnych i urządzeń IIoT montowanych w strefie 2.',
+          },
+          {
+            type: 'paragraph',
+            text: 'W artykule omawiamy wymagania dotyczące testów szczelności, procedury okresowych kontroli oraz wpływ warunków środowiskowych (np. wibracje, temperatura) na trwałość zabezpieczenia.',
+          },
+          {
+            type: 'quote',
+            text: 'W projektach brownfield Ex nR pozwala skrócić czas wdrożenia, ponieważ często wykorzystuje istniejące okablowanie i szafy.',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'inspekcje-utrzymanie',
+    title: '5. Inspekcje i Utrzymanie Ruchu',
+    description:
+      'Treści dla utrzymania ruchu, serwisu, instalatorów i służb BHP.',
+    posts: [
+      {
+        slug: 'pn-en-60079-14',
+        title: 'PN-EN 60079-14 – projektowanie i instalacja',
+        summary:
+          'Najważniejsze wymagania normy instalacyjnej wraz z listą kontrolną dla projektantów.',
+        readTime: '7 min',
+        content: [
+          {
+            type: 'paragraph',
+            text: 'Norma PN-EN 60079-14 opisuje zasady projektowania i montażu instalacji w strefach Ex. Zawiera m.in. wymagania dotyczące kabli, zabezpieczenia przed uszkodzeniami mechanicznymi oraz kontroli jakości wykonania.',
+          },
+          {
+            type: 'paragraph',
+            text: 'Projektanci muszą udokumentować dobór urządzeń, sposób prowadzenia przewodów, rozmieszczenie puszek rozgałęźnych oraz metody uziemienia. W artykule omawiamy też często pomijane aneksy – np. dotyczące ogrzewania przewodów.',
+          },
+          {
+            type: 'list',
+            ordered: true,
+            items: [
+              'Określ klasę temperaturową urządzeń w odniesieniu do medium.',
+              'Zaprojektuj odpowiednie przepusty kablowe (Ex d, Ex e, Ex t).',
+              'Przygotuj plan kontroli jakości montażu i testów odbiorczych.',
+            ],
+          },
+        ],
+      },
+      {
+        slug: 'pn-en-60079-17',
+        title: 'PN-EN 60079-17 – inspekcje i konserwacja',
+        summary:
+          'Jak planować przeglądy, dokumentować działania i utrzymywać zgodność z normą.',
+        readTime: '9 min',
+        content: [
+          {
+            type: 'paragraph',
+            text: 'PN-EN 60079-17 dzieli inspekcje na wizualne, zbliżeniowe i szczegółowe. Zakres i częstotliwość zależą od wyników oceny ryzyka oraz historii instalacji. Norma wymaga także kwalifikacji personelu i prowadzenia rejestru usterek.',
+          },
+          {
+            type: 'paragraph',
+            text: 'W artykule przedstawiamy harmonogram przykładowej rafinerii oraz sposób dokumentowania napraw. Omawiamy również wykorzystanie systemów mobilnych do raportowania usterek w czasie rzeczywistym.',
+          },
+          {
+            type: 'quote',
+            text: 'Kluczem do zgodności jest konsekwencja – jedna baza danych usterek i działań korygujących dla całego zakładu.',
+          },
+        ],
+      },
+      {
+        slug: 'harmonogramy-przegladow',
+        title: 'Harmonogramy przeglądów (checklista PDF)',
+        summary:
+          'Gotowa struktura checklisty dla stref gazowych i pyłowych – do wykorzystania w formie PDF.',
+        readTime: '4 min',
+        content: [
+          {
+            type: 'paragraph',
+            text: 'Checklista obejmuje podział na urządzenia elektryczne, mechaniczne oraz systemy detekcji. W każdej sekcji znajduje się miejsce na ocenę stanu technicznego, termin kolejnej inspekcji i podpis technika.',
+          },
+          {
+            type: 'list',
+            ordered: false,
+            items: [
+              'Weryfikacja oznakowania Ex i numerów seryjnych.',
+              'Kontrola szczelności przepustów oraz stanu kabli.',
+              'Sprawdzenie temperatury powierzchni podczas pracy.',
+            ],
+          },
+          {
+            type: 'paragraph',
+            text: 'Plik PDF jest dostępny w sekcji materiałów do pobrania – można go wypełniać na tablecie lub wydrukować.',
+          },
+        ],
+      },
+      {
+        slug: 'najczestsze-bledy-inspekcje',
+        title: 'Najczęstsze błędy podczas inspekcji (zdjęcia z terenu)',
+        summary:
+          'Galeria realnych przykładów naruszeń norm wraz z komentarzem eksperta.',
+        readTime: '5 min',
+        content: [
+          {
+            type: 'paragraph',
+            text: 'Na zdjęciach prezentujemy m.in. otwarte przepusty kablowe, skorodowane obudowy Ex d oraz nieprawidłowe oznaczenia. Każdy przykład zawiera opis ryzyka i sugerowane działanie korygujące.',
+          },
+          {
+            type: 'list',
+            ordered: false,
+            items: [
+              'Luźne śruby pokryw Ex d – ryzyko utraty szczelności płomieniowej.',
+              'Zabrudzone elementy optyczne bariery fotoelektrycznej – wpływ na bezpieczeństwo funkcjonalne.',
+              'Przewody prowadzone wspólnym korytkiem z obwodami mocy – ryzyko uszkodzenia izolacji.',
+            ],
+          },
+        ],
+      },
+      {
+        slug: 'szablony-protokolow',
+        title: 'Szablony protokołów do inspekcji okresowych (Word/PDF)',
+        summary:
+          'Gotowe szablony raportów, które ułatwiają dokumentowanie przeglądów zgodnie z normą.',
+        readTime: '4 min',
+        content: [
+          {
+            type: 'paragraph',
+            text: 'Szablony obejmują sekcję danych identyfikacyjnych urządzenia, opis usterek, rekomendacje i podpis osoby odpowiedzialnej. Możesz je dostosować do własnych procedur – pliki Word oraz PDF są w sekcji materiałów do pobrania.',
+          },
+          {
+            type: 'paragraph',
+            text: 'Do artykułu dołączamy instrukcję wypełniania dokumentu oraz przykładowy protokół po audycie UDT.',
+          },
+        ],
+      },
+      {
+        slug: 'czyszczenie-urzadzen-ex',
+        title: 'Jak czyścić urządzenia Ex w strefach pyłowych',
+        summary:
+          'Bezpieczne metody usuwania pyłów i zabrudzeń z urządzeń w wykonaniu Ex.',
+        readTime: '5 min',
+        content: [
+          {
+            type: 'paragraph',
+            text: 'Czyszczenie urządzeń w strefach pyłowych wymaga procedur eliminujących ryzyko naelektryzowania oraz uszkodzenia uszczelek. Zaleca się stosowanie odkurzaczy Ex, szczotek antystatycznych i odzieży ESD.',
+          },
+          {
+            type: 'list',
+            ordered: false,
+            items: [
+              'Wyłącz urządzenie i upewnij się, że nie ma atmosfery wybuchowej.',
+              'Używaj narzędzi antystatycznych i unikaj sprężonego powietrza.',
+              'Po czyszczeniu sprawdź uszczelnienia i stan powłok ochronnych.',
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'praktyka-case',
+    title: '6. Praktyka i Case Studies',
+    description:
+      'Realne przykłady z obiektów, audytów i wdrożeń, pokazujące doświadczenie.',
+    posts: [
+      {
+        slug: 'audyt-atex',
+        title: 'Jak wygląda audyt ATEX w zakładzie',
+        summary:
+          'Przebieg audytu krok po kroku – od przygotowania dokumentacji po raport końcowy.',
+        readTime: '6 min',
+        content: [
+          {
+            type: 'paragraph',
+            text: 'Audyt rozpoczyna się od analizy dokumentacji: ocen ryzyka, instrukcji, schematów oraz protokołów z poprzednich inspekcji. Następnie zespół przeprowadza wizję lokalną, fotografuje niezgodności i przeprowadza wywiady z personelem.',
+          },
+          {
+            type: 'paragraph',
+            text: 'Raport końcowy zawiera klasyfikację niezgodności, rekomendacje oraz priorytety działań. Omawiamy, jak przygotować się do audytu, aby zminimalizować czas przestoju i liczbę niespodzianek.',
+          },
+        ],
+      },
+      {
+        slug: 'roznice-pyl-gaz',
+        title: '10 różnic między pyłem a gazem, które psują inspekcje',
+        summary:
+          'Na podstawie doświadczeń z audytów przedstawiamy kluczowe różnice utrudniające kontrole.',
+        readTime: '5 min',
+        content: [
+          {
+            type: 'list',
+            ordered: true,
+            items: [
+              'Pyły tworzą warstwy – trzeba oceniać grubość i temperaturę powierzchni.',
+              'Gaz rozprzestrzenia się szybciej, dlatego liczy się wentylacja i detekcja.',
+              'Urządzenia dla pyłów wymagają testów mechanicznych uszczelnień, a dla gazów – analiz iskrowych.',
+              'Różnice w oznakowaniu EPL (Gb/Gc vs Db/Dc) powodują błędne dobory sprzętu.',
+              'Inspekcje pyłowe często pomijają wnętrza obudów, gdzie gromadzi się pył.',
+              'Różna dokumentacja – PN-EN 60079-10-1 vs 10-2.',
+              'Zastosowanie ochrony przed wyładowaniami elektrostatycznymi.',
+              'Dobór środków czyszczących i procedur sprzątania.',
+              'Wymagania dla klas temperaturowych T vs maksymalna temperatura powierzchni.',
+              'Specyfika prób odbiorczych – np. testy zadziałania odpylaczy.',
+            ],
+          },
+          {
+            type: 'paragraph',
+            text: 'Uwzględnienie tych różnic w planie inspekcji pozwala uniknąć opóźnień i powtarzania audytów.',
+          },
+        ],
+      },
+      {
+        slug: 'najczestsze-awarie',
+        title: 'Najczęstsze awarie i jak ich unikać',
+        summary:
+          'Zestawienie awarii spotykanych w zakładach chemicznych, spożywczych i energetyce.',
+        readTime: '6 min',
+        content: [
+          {
+            type: 'paragraph',
+            text: 'Do najczęstszych awarii należą: uszkodzenia barier na skutek przepięć, korozja obudów Ex d, utrata szczelności przepustów oraz awarie systemów detekcji. Każdą sytuację omawiamy wraz z planem działań zapobiegawczych.',
+          },
+          {
+            type: 'list',
+            ordered: false,
+            items: [
+              'Instaluj ochronę przeciwprzepięciową klasy B+C przed barierami Ex i.',
+              'Regularnie kontroluj momenty dokręcania śrub w obudowach Ex d.',
+              'Kalibruj czujniki detekcji i testuj systemy alarmowe.',
+            ],
+          },
+        ],
+      },
+      {
+        slug: 'przewodnik-zakupowy',
+        title: 'Przewodnik zakupowy: jak dział zakupów powinien wybierać dostawcę',
+        summary:
+          'Checklista dla działów zakupów – od weryfikacji certyfikatów po klauzule serwisowe.',
+        readTime: '5 min',
+        content: [
+          {
+            type: 'paragraph',
+            text: 'Zakupy sprzętu Ex wymagają współpracy z działem technicznym. Należy sprawdzić certyfikaty, referencje dostawcy, warunki gwarancji oraz dostępność serwisu. W artykule prezentujemy matrycę oceny ofert.',
+          },
+          {
+            type: 'list',
+            ordered: true,
+            items: [
+              'Zweryfikuj certyfikację ATEX/IECEx oraz zgodność z wymaganiami projektu.',
+              'Porównaj koszty dostawy, szkolenia, serwisu i części zamiennych.',
+              'Negocjuj klauzule o wsparciu technicznym i dostępności dokumentacji.',
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'nowe-technologie',
+    title: '7. Nowe Technologie i Trendy',
+    description:
+      'Innowacje, które budują wizerunek lidera i wizjonera w branży Ex.',
+    posts: [
+      {
+        slug: 'ethernet-apl',
+        title: 'Ethernet-APL w strefach EX – plusy i minusy',
+        summary:
+          'Analizujemy, kiedy Ethernet-APL przyspiesza komunikację procesową, a kiedy lepiej pozostać przy magistralach klasycznych.',
+        readTime: '6 min',
+        content: [
+          {
+            type: 'paragraph',
+            text: 'Ethernet-APL umożliwia transmisję danych oraz zasilanie po jednej parze przewodów na duże odległości. Standard wspiera urządzenia Ex ia/ib i oferuje przepustowość 10 Mb/s. Omawiamy wymagania dotyczące okablowania i komponentów.',
+          },
+          {
+            type: 'paragraph',
+            text: 'Wadą jest konieczność stosowania specjalnych switchy i zasilaczy w wykonaniu Ex oraz kompatybilności wstecznej z magistralą 4–20 mA. W artykule opisujemy hybrydowe topologie łączące HART-IP z klasycznym HART.',
+          },
+        ],
+      },
+      {
+        slug: 'cyfryzacja-iiot',
+        title: 'Cyfryzacja i IIoT w obszarach zagrożonych wybuchem',
+        summary:
+          'Jak bezpiecznie wdrożyć czujniki IIoT, platformy analityczne i zdalny monitoring w strefach Ex.',
+        readTime: '7 min',
+        content: [
+          {
+            type: 'paragraph',
+            text: 'Transformacja cyfrowa w strefach Ex wymaga certyfikowanych bramek IoT, bezpiecznych protokołów komunikacji i separacji sieci OT/IT. Omawiamy architekturę referencyjną z kontrolą dostępu i monitoringiem zagrożeń.',
+          },
+          {
+            type: 'list',
+            ordered: false,
+            items: [
+              'Wybieraj urządzenia z certyfikatami Ex i/lub Ex d, które wspierają MQTT lub OPC UA.',
+              'Stosuj segmentację sieci i firewalle z funkcjami DPI dla protokołów przemysłowych.',
+              'Zadbaj o zarządzanie certyfikatami i aktualizacje OTA zgodne z wymaganiami ATEX.',
+            ],
+          },
+        ],
+      },
+      {
+        slug: 'cyberbezpieczenstwo-ot',
+        title: 'Cyberbezpieczeństwo OT w strefach Ex (firewall, PoE, edge computing)',
+        summary:
+          'Przewodnik po zabezpieczeniach sieciowych w środowiskach, gdzie liczy się zarówno bezpieczeństwo procesowe, jak i cyber.',
+        readTime: '6 min',
+        content: [
+          {
+            type: 'paragraph',
+            text: 'W strefach Ex coraz częściej stosuje się urządzenia zasilane PoE oraz edge computing. Każdy element musi mieć certyfikację Ex, a jednocześnie spełniać wytyczne IEC 62443. Omawiamy konfigurację firewalli, segmentację VLAN oraz monitorowanie anomalii.',
+          },
+          {
+            type: 'paragraph',
+            text: 'Podkreślamy rolę zarządzania łatami i kopii zapasowych konfiguracji. W artykule znajdziesz listę pytań kontrolnych do audytu cyberbezpieczeństwa w zakładzie procesowym.',
+          },
+        ],
+      },
+      {
+        slug: 'nowe-standardy-iec',
+        title: 'Nowe standardy i przyszłość norm IEC/EN',
+        summary:
+          'Przegląd aktualizacji norm IEC 60079 i EN 60079 oraz kierunki rozwoju standardów w kolejnych latach.',
+        readTime: '5 min',
+        content: [
+          {
+            type: 'paragraph',
+            text: 'Komitety IEC pracują nad aktualizacjami dotyczącymi urządzeń bezprzewodowych, detekcji gazów oraz cyfrowych narzędzi do dokumentacji. W artykule omawiamy najważniejsze zmiany oraz harmonogram publikacji.',
+          },
+          {
+            type: 'list',
+            ordered: false,
+            items: [
+              'Nowe wymagania dotyczące urządzeń wearable w strefach Ex.',
+              'Rozszerzenie norm o zagadnienia cyberbezpieczeństwa.',
+              'Integracja z systemami zarządzania bezpieczeństwem procesowym (IEC 61511).',
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'branze-zastosowania',
+    title: '8. Branże i Zastosowania',
+    description:
+      'Artykuły pod SEO, pokazujące uniwersalność i specyfikę tematu w różnych gałęziach przemysłu.',
+    posts: [
+      {
+        slug: 'atex-w-gornictwie',
+        title: 'ATEX w górnictwie – specyfika i wymagania',
+        summary:
+          'Wyjaśniamy, dlaczego górnictwo ma własne grupy wybuchowości i jakie dodatkowe procedury obowiązują.',
+        readTime: '6 min',
+        content: [
+          {
+            type: 'paragraph',
+            text: 'Górnictwo posługuje się grupą I (metan) i wymaga sprzętu odpornego na pył węglowy oraz wstrząsy. Omawiamy przepisy Wyższego Urzędu Górniczego, dodatkowe wymagania dla urządzeń transportowych i stacji transformatorowych.',
+          },
+          {
+            type: 'paragraph',
+            text: 'Ważne są także procedury ewakuacyjne oraz redundancja systemów detekcji metanu. W artykule przedstawiamy przykłady z polskich kopalń.',
+          },
+        ],
+      },
+      {
+        slug: 'atex-w-petrochemii',
+        title: 'ATEX w petrochemii i rafineriach',
+        summary:
+          'Kluczowe zagadnienia dla rafinerii – od klasyfikacji stref po integrację z systemami SIS.',
+        readTime: '6 min',
+        content: [
+          {
+            type: 'paragraph',
+            text: 'Rafinerie charakteryzują się rozległą infrastrukturą, mieszaninami węglowodorów i wysoką temperaturą procesów. Omawiamy klasyfikację stref w rejonie kolumn destylacyjnych, pochodni oraz instalacji magazynowych.',
+          },
+          {
+            type: 'paragraph',
+            text: 'Opisujemy również współpracę systemów SIS (Safety Instrumented Systems) z aparaturą Ex oraz znaczenie testów proof test.',
+          },
+        ],
+      },
+      {
+        slug: 'atex-w-spozywce',
+        title: 'ATEX w spożywce – mąka, cukier, pyły organiczne',
+        summary:
+          'Jak projektować linie produkcyjne z pyłami organicznymi i uniknąć przestojów spowodowanych wybuchem.',
+        readTime: '5 min',
+        content: [
+          {
+            type: 'paragraph',
+            text: 'Branża spożywcza zmaga się z pyłami mąki, cukru i przypraw. W artykule omawiamy wymagania dotyczące odpylania, monitorowania temperatury łożysk oraz zabezpieczeń przed zapłonem w silosach.',
+          },
+          {
+            type: 'list',
+            ordered: false,
+            items: [
+              'Regularne czyszczenie instalacji transportu pneumatycznego.',
+              'Systemy detekcji iskier i gaszenia w kanałach odpylających.',
+              'Szkolenia personelu w zakresie pracy w strefach pyłowych.',
+            ],
+          },
+        ],
+      },
+      {
+        slug: 'atex-w-farmacji',
+        title: 'ATEX w farmacji – produkcja leków i pyły farmaceutyczne',
+        summary:
+          'Specyfika produkcji farmaceutyków: higiena, pyły wybuchowe i ścisła kontrola procesów.',
+        readTime: '6 min',
+        content: [
+          {
+            type: 'paragraph',
+            text: 'W farmacji kluczowe są strefy czyste oraz jednoczesne spełnienie wymagań GMP i ATEX. Omawiamy projektowanie systemów odpylania, izolatorów oraz odzieży antystatycznej.',
+          },
+          {
+            type: 'paragraph',
+            text: 'W artykule wskazujemy także na rolę walidacji czystości mikrobiologicznej po pracach w strefach Ex.',
+          },
+        ],
+      },
+      {
+        slug: 'atex-w-logistyce',
+        title: 'ATEX w logistyce i silosach',
+        summary:
+          'Bezpieczne magazynowanie i transport materiałów sypkich oraz paliw płynnych.',
+        readTime: '5 min',
+        content: [
+          {
+            type: 'paragraph',
+            text: 'Logistyka obejmuje magazyny paliw, terminale przeładunkowe i silosy. Kluczowe są systemy wentylacji, detekcja gazów oraz ochrona przed elektrycznością statyczną.',
+          },
+          {
+            type: 'paragraph',
+            text: 'W artykule omawiamy zasady uziemiania cystern, kontrolę stanu filtrów oraz wymagania dla układów odprowadzania ładunków.',
+          },
+        ],
+      },
+      {
+        slug: 'atex-w-bateriach',
+        title: 'ATEX w branży baterii i magazynach energii',
+        summary:
+          'Nowa gałąź przemysłu – ryzyka związane z elektrolitem i pyłami metali lekkich.',
+        readTime: '6 min',
+        content: [
+          {
+            type: 'paragraph',
+            text: 'Produkcja baterii litowo-jonowych generuje pyły metali oraz emisję rozpuszczalników. Omawiamy wymagania dotyczące systemów wentylacji, monitoringu temperatury oraz ochrony przeciwpożarowej.',
+          },
+          {
+            type: 'paragraph',
+            text: 'Dodatkowe wyzwanie to integracja z systemami BMS i zabezpieczenie przed zwarciami w strefach montażu modułów.',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'edukacja-poradniki',
+    title: '9. Edukacja i Poradniki',
+    description:
+      'Dedykowane materiały dla różnych ról w organizacji: od inżyniera do kupca.',
+    posts: [
+      {
+        slug: 'atex-dla-bhp',
+        title: 'ATEX dla BHP-owca – co musi wiedzieć',
+        summary:
+          'Najważniejsze obowiązki służb BHP w zakładach z atmosferami wybuchowymi.',
+        readTime: '5 min',
+        content: [
+          {
+            type: 'paragraph',
+            text: 'Specjalista BHP powinien znać klasyfikację stref, procedury ewakuacyjne, wymagania dotyczące szkoleń oraz sposób dokumentowania zdarzeń potencjalnie niebezpiecznych. Omawiamy też współpracę z inspektorami UDT i PSP.',
+          },
+          {
+            type: 'list',
+            ordered: false,
+            items: [
+              'Prowadzenie rejestru prac niebezpiecznych.',
+              'Koordynacja szkoleń i instruktaży dla pracowników oraz podwykonawców.',
+              'Monitorowanie działań korygujących po audytach.',
+            ],
+          },
+        ],
+      },
+      {
+        slug: 'atex-dla-zakupow',
+        title: 'ATEX dla działu zakupów – jak nie kupić bubla',
+        summary:
+          'Praktyczne wskazówki dotyczące oceny ofert i zapisów umownych związanych z urządzeniami Ex.',
+        readTime: '4 min',
+        content: [
+          {
+            type: 'paragraph',
+            text: 'Dział zakupów powinien współpracować z inżynierami już na etapie specyfikacji. W artykule przedstawiamy listę pytań do dostawcy oraz wzór klauzuli o dostarczeniu kompletu dokumentów Ex.',
+          },
+          {
+            type: 'paragraph',
+            text: 'Podkreślamy wagę audytów fabrycznych (FAT) i odbiorów SAT, a także zasady odbioru magazynowego sprzętu Ex.',
+          },
+        ],
+      },
+      {
+        slug: 'atex-dla-projektanta',
+        title: 'ATEX dla projektanta instalacji elektrycznych',
+        summary:
+          'Kompendium dla projektantów: od analizy ryzyka po dobór kabli i zabezpieczeń.',
+        readTime: '6 min',
+        content: [
+          {
+            type: 'paragraph',
+            text: 'Projektant odpowiada za spójność dokumentacji: schematów, planów kablowych, opisów technicznych i kosztorysów. Omawiamy rolę koordynacji z branżami mechaniczną oraz automatyki.',
+          },
+          {
+            type: 'list',
+            ordered: true,
+            items: [
+              'Analiza dokumentów: ocena ryzyka, wykaz urządzeń, dane procesowe.',
+              'Dobór kabli, przepustów, zabezpieczeń i systemów monitoringu.',
+              'Przygotowanie instrukcji montażowych i planu testów funkcjonalnych.',
+            ],
+          },
+        ],
+      },
+      {
+        slug: 'mini-slownik-ex',
+        title: 'Mini słownik: najważniejsze pojęcia i skróty Ex',
+        summary:
+          'Szybkie przypomnienie terminologii – od EPL i EPL Ga po EPL Db oraz moduły oceny zgodności.',
+        readTime: '4 min',
+        content: [
+          {
+            type: 'list',
+            ordered: false,
+            items: [
+              'EPL – Equipment Protection Level, poziom ochrony urządzenia.',
+              'IP – stopień ochrony przed wnikaniem ciał stałych i wody.',
+              'DoC – deklaracja zgodności UE.',
+              'FAT/SAT – testy fabryczne i na obiekcie.',
+              'SIL – poziom nienaruszalności bezpieczeństwa dla systemów SIS.',
+            ],
+          },
+          {
+            type: 'paragraph',
+            text: 'Słownik można pobrać jako plakat PDF z sekcji materiałów. Przydatny podczas szkoleń i onboardingu nowych pracowników.',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'materialy-do-pobrania',
+    title: '10. Materiały do Pobrania',
+    description:
+      'Praktyczne narzędzia i szablony, które generują leady i budują bazę kontaktów.',
+    posts: [
+      {
+        slug: 'kalkulator-exi',
+        title: 'Kalkulator XLS do dowodzenia Ex i',
+        summary:
+          'Arkusz kalkulacyjny pomagający zweryfikować parametry obwodów iskrobezpiecznych.',
+        readTime: '3 min',
+        content: [
+          {
+            type: 'paragraph',
+            text: 'Kalkulator zawiera zakładki do obliczeń dla barier analogowych, cyfrowych oraz sygnałów NAMUR. Uwzględnia automatyczne ostrzeżenia przy przekroczeniu parametrów C₀/L₀ oraz możliwość generowania raportu PDF.',
+          },
+          {
+            type: 'paragraph',
+            text: 'Do pakietu dołączamy instrukcję użytkowania oraz przykładową kartę obwodu, którą można zaadaptować w dokumentacji zakładowej.',
+          },
+        ],
+      },
+      {
+        slug: 'checklista-60079-17',
+        title: 'Checklista PDF do inspekcji PN-EN 60079-17',
+        summary:
+          'Lista kontrolna obejmująca ponad 40 punktów kontrolnych dla stref gazowych i pyłowych.',
+        readTime: '3 min',
+        content: [
+          {
+            type: 'paragraph',
+            text: 'Checklista w formacie PDF/Excel zawiera sekcje dotyczące oględzin wizualnych, zbliżeniowych oraz szczegółowych. Można ją łączyć z systemami CMMS.',
+          },
+          {
+            type: 'list',
+            ordered: false,
+            items: [
+              'Sekcja identyfikacyjna urządzenia (ID, lokalizacja, strefa).',
+              'Lista niezgodności z możliwością przypisania działań korygujących.',
+              'Automatyczne podsumowanie statusu instalacji.',
+            ],
+          },
+        ],
+      },
+      {
+        slug: 'protokol-inspekcyjny',
+        title: 'Protokół inspekcyjny do druku (Word/PDF)',
+        summary:
+          'Szablon dokumentu ułatwiający raportowanie wyników przeglądów i audytów.',
+        readTime: '2 min',
+        content: [
+          {
+            type: 'paragraph',
+            text: 'Szablon zawiera pola na dane obiektu, opis usterek, rekomendacje, osoby odpowiedzialne i terminy realizacji. Dostępny w wersji Word oraz w edytowalnym PDF.',
+          },
+          {
+            type: 'paragraph',
+            text: 'W artykule opisujemy sposób integracji protokołu z systemem zarządzania dokumentacją oraz przykładowe wpisy.',
+          },
+        ],
+      },
+      {
+        slug: 'schematy-eplan',
+        title: 'Schematy przykładowe w EPLAN/Visio',
+        summary:
+          'Pakiet plików źródłowych z aktualnymi symbolami Ex i przykładowymi obwodami.',
+        readTime: '4 min',
+        content: [
+          {
+            type: 'paragraph',
+            text: 'Udostępniamy bibliotekę symboli oraz przykładowe schematy dla obwodów Ex i, Ex d oraz Ex t. Pliki są zgodne z aktualnymi normami i ułatwiają przygotowanie dokumentacji warsztatowej.',
+          },
+          {
+            type: 'paragraph',
+            text: 'Dołączamy instrukcję importu do EPLAN i Microsoft Visio oraz wskazówki dotyczące utrzymania szablonów.',
+          },
+        ],
+      },
+      {
+        slug: 'specyfikacja-dla-zakupow',
+        title: 'Przykładowa specyfikacja dla działu zakupów',
+        summary:
+          'Gotowy wzór specyfikacji technicznej z listą wymagań i kryteriów oceny dostawców.',
+        readTime: '3 min',
+        content: [
+          {
+            type: 'paragraph',
+            text: 'Specyfikacja zawiera opis urządzenia, wymagania certyfikacyjne, parametry środowiskowe, kryteria oceny ofert oraz klauzule dotyczące dostawy dokumentacji. Można ją wypełnić w arkuszu kalkulacyjnym lub w systemie ERP.',
+          },
+          {
+            type: 'paragraph',
+            text: 'Dodatkowe pola obejmują termin dostawy, warunki gwarancji, szkolenia oraz wsparcie serwisowe.',
+          },
+        ],
+      },
+    ],
+  },
+];
+
+function findPostBySlug(slug) {
+  for (const category of categories) {
+    const post = category.posts.find((item) => item.slug === slug);
+    if (post) {
+      return { ...post, category: category.title };
+    }
+  }
+  return undefined;
+}
+if (typeof window !== 'undefined') {
+  window.ATEX_DATA = {
+    categories,
+    findPostBySlug,
+  };
+}

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -1,0 +1,340 @@
+let categories = [];
+
+document.addEventListener('DOMContentLoaded', () => {
+  const data = window.ATEX_DATA || {};
+  categories = Array.isArray(data.categories) ? data.categories : [];
+
+  initNavigation();
+  renderCategories();
+  initGame();
+  setCurrentYear();
+});
+
+function initNavigation() {
+  const toggle = document.querySelector('.nav-toggle');
+  const menu = document.querySelector('.nav-links');
+
+  if (!toggle || !menu) {
+    return;
+  }
+
+  toggle.addEventListener('click', () => {
+    const expanded = toggle.getAttribute('aria-expanded') === 'true';
+    toggle.setAttribute('aria-expanded', String(!expanded));
+    menu.classList.toggle('nav-links--open');
+  });
+
+  menu.querySelectorAll('a').forEach((link) => {
+    link.addEventListener('click', () => {
+      toggle.setAttribute('aria-expanded', 'false');
+      menu.classList.remove('nav-links--open');
+    });
+  });
+}
+
+function renderCategories() {
+  const grid = document.querySelector('[data-category-grid]');
+  if (!grid) return;
+
+  const iconLibrary = {
+    'podstawy-ex':
+      '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"></path><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"></path></svg>',
+    'prawo-i-cert':
+      '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"></path><polyline points="14 2 14 8 20 8"></polyline><path d="m10 13-2 2 2 2"></path><path d="m14 17 2-2-2-2"></path></svg>',
+    'dowodzenie-iskrobezpieczenstwa':
+      '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><line x1="8" y1="12" x2="16" y2="12"></line><line x1="12" y1="8" x2="12" y2="16"></line></svg>',
+    'urzadzenia-bariery':
+      '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12.2619 3.5 11.2333v1.5334L2 13.7381V12.2619Z"></path><path d="M5 10.2333 6.5 9.2333v5.5334L5 15.7667V10.2333Z"></path><path d="M8 8.2333 9.5 7.2333v9.5334L8 17.7667V8.2333Z"></path><path d="M11 6.2333 12.5 5.2333v13.5334L11 19.7667V6.2333Z"></path><path d="M14 8.2333 15.5 7.2333v9.5334L14 17.7667V8.2333Z"></path><path d="M17 10.2333 18.5 9.2333v5.5334L17 15.7667V10.2333Z"></path><path d="M20 12.2619 21.5 11.2333v1.5334L20 13.7381V12.2619Z"></path></svg>',
+    'inspekcje-utrzymanie':
+      '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>',
+    'praktyka-case':
+      '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><path d="M12 18v-6"></path><path d="M12 8h.01"></path></svg>',
+    'nowe-technologie':
+      '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"></path><path d="M12 5l7 7-7 7"></path></svg>',
+    'branze-zastosowania':
+      '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 9 12 2l9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"></path><polyline points="9 22 9 12 15 12 15 22"></polyline></svg>',
+    'edukacja-poradniki':
+      '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2 2 7l10 5 10-5-10-5z"></path><path d="M2 17l10 5 10-5"></path><path d="M2 12l10 5 10-5"></path></svg>',
+    'materialy-do-pobrania':
+      '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>',
+  };
+
+  categories.forEach((category) => {
+    const card = document.createElement('article');
+    card.className = 'category-card';
+    card.tabIndex = 0;
+    card.setAttribute('role', 'link');
+    card.setAttribute('aria-label', `Przejdź do sekcji ${category.title}`);
+
+    const icon = document.createElement('span');
+    icon.className = 'category-card__icon';
+    icon.innerHTML = iconLibrary[category.id] ?? '';
+
+    const title = document.createElement('h3');
+    title.textContent = category.title;
+
+    const description = document.createElement('p');
+    description.className = 'category-card__description';
+    description.textContent = category.description;
+
+    const button = document.createElement('span');
+    button.className = 'category-card__cta';
+    button.textContent = 'Zobacz tematy';
+
+    card.append(icon, title, description, button);
+
+    const openCategory = () => {
+      window.location.href = `category.html?category=${encodeURIComponent(category.id)}`;
+    };
+
+    card.addEventListener('click', openCategory);
+    card.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        openCategory();
+      }
+    });
+
+    grid.append(card);
+  });
+}
+
+function initGame() {
+  const game = document.querySelector('[data-game]');
+  if (!game) return;
+
+  const nextButton = game.querySelector('[data-next]');
+  const resetButton = game.querySelector('[data-reset]');
+  const feedback = game.querySelector('[data-feedback]');
+  const scoreNode = game.querySelector('[data-score]');
+  const roundNode = game.querySelector('[data-round]');
+  const optionsList = game.querySelector('[data-options]');
+  const heading = game.querySelector('[data-scenario-heading]');
+  const description = game.querySelector('[data-scenario-description]');
+
+  const scenarios = createScenarios();
+  let currentScenario = null;
+  let answered = false;
+  let score = 0;
+  let rounds = 0;
+
+  function renderScenario() {
+    const available = scenarios.filter((scenario) => scenario !== currentScenario);
+    currentScenario = available[Math.floor(Math.random() * available.length)];
+
+    heading.textContent = currentScenario.heading;
+    description.textContent = currentScenario.description;
+    optionsList.innerHTML = '';
+    answered = false;
+
+    currentScenario.options.forEach((option) => {
+      const item = document.createElement('li');
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'game-option';
+      button.textContent = option.label;
+      button.addEventListener('click', () => handleAnswer(option));
+      item.append(button);
+      optionsList.append(item);
+    });
+
+    feedback.textContent = 'Wybierz odpowiedź, aby sprawdzić wynik.';
+  }
+
+  function handleAnswer(option) {
+    if (answered) {
+      return;
+    }
+
+    answered = true;
+    rounds += 1;
+
+    const allButtons = optionsList.querySelectorAll('button');
+    allButtons.forEach((button) => {
+      button.disabled = true;
+      if (option.correct && button.textContent === option.label) {
+        button.classList.add('game-option--correct');
+      }
+    });
+
+    if (option.correct) {
+      score += 1;
+      feedback.textContent = `Świetnie! ${option.explanation}`;
+    } else {
+      feedback.textContent = `Nie tym razem. ${option.explanation}`;
+      const correct = currentScenario.options.find((item) => item.correct);
+      if (correct) {
+        const correctButton = Array.from(allButtons).find((button) => button.textContent === correct.label);
+        if (correctButton) {
+          correctButton.classList.add('game-option--correct');
+        }
+      }
+    }
+
+    scoreNode.textContent = String(score);
+    roundNode.textContent = String(rounds);
+  }
+
+  function resetGame() {
+    score = 0;
+    rounds = 0;
+    scoreNode.textContent = '0';
+    roundNode.textContent = '0';
+    feedback.textContent = 'Gra została zresetowana. Wylosuj nowe pytanie.';
+    optionsList.innerHTML = '';
+    heading.textContent = 'Losuj pytanie, aby rozpocząć';
+    description.textContent = 'Przygotuj się na nowe wyzwanie dobierania urządzeń w strefach Ex.';
+    currentScenario = null;
+    answered = false;
+  }
+
+  nextButton.addEventListener('click', () => {
+    renderScenario();
+    roundNode.textContent = String(rounds);
+  });
+
+  resetButton.addEventListener('click', resetGame);
+}
+
+function createScenarios() {
+  return [
+    {
+      heading: 'Strefa 0 (gazy) – pomiar poziomu w zbiorniku',
+      description:
+        'Zbiornik z rozpuszczalnikiem o niskiej temperaturze zapłonu. Czujnik jest zanurzony w medium, konserwacja odbywa się bez odłączania zasilania.',
+      options: [
+        {
+          label: 'Czujnik poziomu ultradźwiękowy Ex ia, kat. 1G',
+          correct: true,
+          explanation: 'Dla strefy 0 wymagane jest urządzenie kat. 1G lub EPL Ga, dlatego wybór Ex ia jest właściwy.',
+        },
+        {
+          label: 'Radar poziomu w obudowie Ex d, kat. 2G',
+          correct: false,
+          explanation: 'Kat. 2G (EPL Gb) nie może być stosowana w strefie 0 – wymaga ona co najmniej kat. 1G.',
+        },
+        {
+          label: 'Przepływomierz standardowy IP67 bez certyfikatu ATEX',
+          correct: false,
+          explanation: 'Brak certyfikacji ATEX uniemożliwia montaż w strefach zagrożonych wybuchem.',
+        },
+      ],
+    },
+    {
+      heading: 'Strefa 1 (gazy) – sterowanie zaworem',
+      description:
+        'Na instalacji gazu syntezowego potrzebny jest pozycjoner do sterowania zaworem regulacyjnym. Dostępne jest uziemienie i prowadzenie przewodów w korytach kablowych.',
+      options: [
+        {
+          label: 'Pozycjoner pneumatyczny Ex ia z barierą galwaniczną',
+          correct: true,
+          explanation: 'Połączenie Ex ia z barierą galwaniczną spełnia wymagania strefy 1 i zapewnia separację galwaniczną.',
+        },
+        {
+          label: 'Pozycjoner w wykonaniu Ex nA',
+          correct: false,
+          explanation: 'Ex nA (kategoria 3G) przeznaczony jest do strefy 2, a nie do strefy 1.',
+        },
+        {
+          label: 'Pozycjoner standardowy IP54',
+          correct: false,
+          explanation: 'Brak certyfikatu Ex powoduje, że urządzenie nie może być użyte w strefach 1/2.',
+        },
+      ],
+    },
+    {
+      heading: 'Strefa 2 (gazy) – monitoring drgań',
+      description:
+        'Wentylatory dachowe na rafinerii wymagają monitorowania drgań. Przestoje są kosztowne, dlatego liczy się szybki montaż.',
+      options: [
+        {
+          label: 'Akcelerometr Ex nR z ogranicznikiem oddychania',
+          correct: true,
+          explanation: 'Ex nR zapewnia restricted breathing i jest przeznaczony do strefy 2 (kategoria 3G).',
+        },
+        {
+          label: 'Czujnik drgań Ex t dla stref pyłowych',
+          correct: false,
+          explanation: 'Urządzenie Ex t dotyczy stref pyłowych – w środowisku gazowym nie zapewni właściwej ochrony.',
+        },
+        {
+          label: 'Akcelerometr Ex d, kat. 1G',
+          correct: false,
+          explanation: 'Choć spełnia wymagania bezpieczeństwa, to rozwiązanie jest przewymiarowane kosztowo i niepotrzebnie ciężkie.',
+        },
+      ],
+    },
+    {
+      heading: 'Strefa 21 (pyły) – dozowanie mąki',
+      description:
+        'Linia pakowania mąki posiada przewały i dozowniki ślimakowe. Konieczny jest czujnik prędkości kontrolujący ruch ślimaka.',
+      options: [
+        {
+          label: 'Czujnik indukcyjny Ex tb IIIC z uszczelnieniem pyłoszczelnym',
+          correct: true,
+          explanation: 'W strefie 21 wymagane jest EPL Db lub kategoria 2D – Ex tb IIIC spełnia to kryterium.',
+        },
+        {
+          label: 'Czujnik fotoelektryczny Ex ia, kat. 1G',
+          correct: false,
+          explanation: 'Certyfikacja 1G dotyczy stref gazowych; brak dopuszczenia dla pyłów (D).',
+        },
+        {
+          label: 'Czujnik standardowy IP65 z filtrem przeciwpyłowym',
+          correct: false,
+          explanation: 'Stopień IP nie zastępuje certyfikacji ATEX dla stref pyłowych.',
+        },
+      ],
+    },
+    {
+      heading: 'Strefa 22 (pyły) – magazyn cukru',
+      description:
+        'Magazyn cukru z instalacją transportu pneumatycznego wymaga lokalnych wyłączników awaryjnych na zasuwach.',
+      options: [
+        {
+          label: 'Wyłącznik awaryjny Ex tc IIIC IP66',
+          correct: true,
+          explanation: 'Ex tc przeznaczony jest do strefy 22 (kategoria 3D) i zapewnia pyłoszczelność obudowy.',
+        },
+        {
+          label: 'Wyłącznik w wykonaniu Ex nA',
+          correct: false,
+          explanation: 'Ex nA dotyczy atmosfer gazowych i nie zapewnia ochrony przed pyłami.',
+        },
+        {
+          label: 'Zwykły wyłącznik stalowy IP67',
+          correct: false,
+          explanation: 'Brak certyfikatu ATEX – IP67 nie wystarcza w strefach 22.',
+        },
+      ],
+    },
+    {
+      heading: 'Strefa mieszana – terminal ładowania cystern',
+      description:
+        'Terminal obsługuje benzynę oraz pyły aluminiowe. Potrzebny jest system detekcji gazów i pyłów w jednym układzie sterowania.',
+      options: [
+        {
+          label: 'System detekcji z modułem Ex ia i sondami kat. 1G/1D',
+          correct: true,
+          explanation: 'Zintegrowany system Ex ia dla gazów i pyłów zapewnia najwyższy poziom bezpieczeństwa w strefach mieszanych.',
+        },
+        {
+          label: 'Czujniki gazów Ex d oraz pyłów Ex t sterowane PLC ogólnego przeznaczenia',
+          correct: false,
+          explanation: 'Sterownik ogólnego przeznaczenia bez barier separujących nie spełnia wymogów bezpieczeństwa.',
+        },
+        {
+          label: 'System detekcji bez certyfikacji, zasilany z UPS',
+          correct: false,
+          explanation: 'Brak certyfikacji wyklucza wykorzystanie w strefach zagrożonych wybuchem.',
+        },
+      ],
+    },
+  ];
+}
+
+function setCurrentYear() {
+  document.querySelectorAll('[data-year]').forEach((element) => {
+    element.textContent = String(new Date().getFullYear());
+  });
+}

--- a/scripts/post.js
+++ b/scripts/post.js
@@ -1,0 +1,162 @@
+let categories = [];
+let getPostBySlug = () => undefined;
+
+document.addEventListener('DOMContentLoaded', () => {
+  const data = window.ATEX_DATA || {};
+  categories = Array.isArray(data.categories) ? data.categories : [];
+  getPostBySlug = typeof data.findPostBySlug === 'function' ? data.findPostBySlug : () => undefined;
+
+  initNavigation();
+  renderArticle();
+  setCurrentYear();
+});
+
+function initNavigation() {
+  const toggle = document.querySelector('.nav-toggle');
+  const menu = document.querySelector('.nav-links');
+
+  if (!toggle || !menu) return;
+
+  toggle.addEventListener('click', () => {
+    const expanded = toggle.getAttribute('aria-expanded') === 'true';
+    toggle.setAttribute('aria-expanded', String(!expanded));
+    menu.classList.toggle('nav-links--open');
+  });
+
+  menu.querySelectorAll('a').forEach((link) => {
+    link.addEventListener('click', () => {
+      toggle.setAttribute('aria-expanded', 'false');
+      menu.classList.remove('nav-links--open');
+    });
+  });
+}
+
+function renderArticle() {
+  const params = new URLSearchParams(window.location.search);
+  const slug = params.get('slug');
+  const categoryParam = params.get('category');
+
+  const article = document.querySelector('[data-article]');
+  const articleTitle = document.querySelector('#article-title');
+  const articleMeta = document.querySelector('[data-article-meta]');
+  const contentContainer = document.querySelector('[data-article-content]');
+  const heroHeading = document.querySelector('[data-hero-heading]');
+  const heroLead = document.querySelector('[data-hero-lead]');
+  const badge = document.querySelector('[data-category-pill]');
+  const backLink = document.querySelector('[data-breadcrumb-category]');
+  const backToCategoryButton = document.querySelector('[data-back-to-category]');
+
+  if (!article || !articleMeta || !contentContainer || !heroHeading) {
+    return;
+  }
+
+  if (!slug) {
+    renderError('Nie znaleziono artykułu. Wróć do listy sekcji, aby wybrać temat.');
+    return;
+  }
+
+  const post = getPostBySlug(slug);
+
+  if (!post) {
+    renderError('Ups! Wpis, którego szukasz, nie istnieje lub został przeniesiony.');
+    return;
+  }
+
+  const category = categories.find((item) => item.title === post.category);
+  const isValidParam = categoryParam && categories.some((item) => item.id === categoryParam);
+  const categoryId = isValidParam ? categoryParam : category ? category.id : undefined;
+
+  heroHeading.textContent = post.title;
+  if (heroLead) {
+    heroLead.textContent = post.summary;
+  }
+  if (articleTitle) {
+    articleTitle.textContent = post.title;
+  }
+  if (badge && post.category) {
+    badge.textContent = post.category;
+  }
+  article.setAttribute('aria-labelledby', 'article-title');
+
+  document.title = `${post.title} – ATEXpert`;
+
+  const metaParts = [];
+  if (post.category) {
+    metaParts.push(post.category);
+  }
+  if (post.readTime) {
+    metaParts.push(`czas czytania: ${post.readTime}`);
+  }
+  articleMeta.textContent = metaParts.join(' • ');
+
+  if (categoryId && backLink && backToCategoryButton) {
+    const url = `category.html?category=${encodeURIComponent(categoryId)}`;
+    backLink.href = url;
+    backToCategoryButton.href = url;
+  }
+
+  contentContainer.innerHTML = '';
+  post.content.forEach((block) => {
+    switch (block.type) {
+      case 'paragraph': {
+        const paragraph = document.createElement('p');
+        paragraph.textContent = block.text;
+        contentContainer.append(paragraph);
+        break;
+      }
+      case 'list': {
+        const list = document.createElement(block.ordered ? 'ol' : 'ul');
+        block.items.forEach((item) => {
+          const li = document.createElement('li');
+          li.textContent = item;
+          list.append(li);
+        });
+        contentContainer.append(list);
+        break;
+      }
+      case 'quote': {
+        const figure = document.createElement('blockquote');
+        figure.textContent = block.text;
+        contentContainer.append(figure);
+        break;
+      }
+      case 'heading': {
+        const level = Math.min(Math.max(block.level || 2, 2), 4);
+        const headingElement = document.createElement(`h${level}`);
+        headingElement.textContent = block.text;
+        contentContainer.append(headingElement);
+        break;
+      }
+      default:
+        break;
+    }
+  });
+}
+
+function renderError(message) {
+  const container = document.querySelector('[data-article]');
+  const heroHeading = document.querySelector('[data-hero-heading]');
+  if (heroHeading) {
+    heroHeading.textContent = 'Wpis nie został znaleziony';
+  }
+  if (!container) return;
+
+  container.innerHTML = `
+    <div class="article">
+      <h1>Wpis nie został znaleziony</h1>
+      <p>${message}</p>
+      <a class="back-link" href="index.html">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <polyline points="15 18 9 12 15 6"></polyline>
+        </svg>
+        Wróć do strony głównej
+      </a>
+    </div>
+  `;
+}
+
+function setCurrentYear() {
+  document.querySelectorAll('[data-year]').forEach((element) => {
+    element.textContent = String(new Date().getFullYear());
+  });
+}

--- a/styles/main.css
+++ b/styles/main.css
@@ -1,0 +1,624 @@
+/*
+  Global styles for ATEXpert static application.
+  Zapewniają responsywny układ kart, sekcji hero oraz gry edukacyjnej.
+*/
+
+:root {
+  --c-primary: #0b5c5e;
+  --c-secondary: #0e2a47;
+  --c-accent: #e2b714;
+  --c-background: #ffffff;
+  --c-surface: #f7fafc;
+  --c-border: #e0e6ed;
+  --c-muted: #5b6b7c;
+  --shadow-lg: 0 20px 45px rgba(14, 42, 71, 0.15);
+  --shadow-sm: 0 10px 25px rgba(14, 42, 71, 0.08);
+  color-scheme: only light;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  line-height: 1.6;
+  color: var(--c-secondary);
+  background: var(--c-background);
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  color: var(--c-primary);
+}
+
+.skip-link {
+  position: absolute;
+  top: -100px;
+  left: 16px;
+  background: var(--c-accent);
+  color: var(--c-secondary);
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  z-index: 200;
+  transition: top 0.2s ease;
+}
+
+.skip-link:focus {
+  top: 16px;
+}
+
+.navbar {
+  position: sticky;
+  top: 0;
+  width: 100%;
+  background: rgba(255, 255, 255, 0.92);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--c-border);
+  z-index: 150;
+}
+
+.nav-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 1rem 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.logo {
+  font-size: 1.6rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--c-primary);
+}
+
+.nav-toggle {
+  background: transparent;
+  border: 1px solid var(--c-border);
+  border-radius: 0.5rem;
+  padding: 0.4rem 0.9rem;
+  font-weight: 600;
+  color: var(--c-secondary);
+  cursor: pointer;
+  display: none;
+}
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.nav-links a {
+  font-weight: 500;
+  color: var(--c-secondary);
+  transition: color 0.2s ease;
+}
+
+.nav-links a:hover,
+.nav-links a:focus {
+  color: var(--c-primary);
+}
+
+.hero {
+  position: relative;
+  padding: 6rem 0 5rem;
+  background: linear-gradient(130deg, rgba(11, 92, 94, 0.78), rgba(14, 42, 71, 0.9)),
+    url('../images/hero-pattern.svg');
+  background-size: cover;
+  background-position: center;
+  color: #fff;
+}
+
+.hero--compact {
+  padding: 4.5rem 0 3.5rem;
+}
+
+.hero-inner {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 2.5rem;
+}
+
+.hero-copy {
+  max-width: 650px;
+}
+
+.hero h1 {
+  margin: 0;
+  font-size: clamp(2.4rem, 4vw, 3.6rem);
+  line-height: 1.1;
+}
+
+.intro-text {
+  font-size: 1.1rem;
+  color: rgba(255, 255, 255, 0.9);
+  margin: 1.5rem 0;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  background: rgba(226, 183, 20, 0.2);
+  color: #fef6d0;
+  border-radius: 999px;
+  padding: 0.4rem 0.85rem;
+  margin-bottom: 1.25rem;
+}
+
+.cta-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.primary,
+.secondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.5rem;
+  border-radius: 0.65rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.primary {
+  background: var(--c-accent);
+  color: var(--c-secondary);
+  box-shadow: var(--shadow-sm);
+}
+
+.primary:hover,
+.primary:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 35px rgba(226, 183, 20, 0.35);
+}
+
+.secondary {
+  background: rgba(255, 255, 255, 0.12);
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.secondary:hover,
+.secondary:focus {
+  background: rgba(255, 255, 255, 0.25);
+}
+
+.hero-highlight {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  min-width: 220px;
+  color: rgba(255, 255, 255, 0.8);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+}
+
+.hero-highlight span {
+  padding: 0.65rem 1rem;
+  border-radius: 0.65rem;
+  background: rgba(255, 255, 255, 0.12);
+  text-transform: uppercase;
+  text-align: center;
+}
+
+.wrap {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+.section {
+  padding: 4rem 0;
+}
+
+.section-heading {
+  max-width: 700px;
+  margin-bottom: 2rem;
+}
+
+.section-heading h2 {
+  margin: 0 0 0.5rem;
+  color: var(--c-secondary);
+  font-size: clamp(1.8rem, 3vw, 2.4rem);
+}
+
+.section-heading p {
+  color: var(--c-muted);
+  margin: 0;
+}
+
+.category-grid {
+  display: grid;
+  gap: 1.8rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.category-card {
+  background: var(--c-surface);
+  border: 1px solid var(--c-border);
+  border-radius: 1rem;
+  padding: 2rem 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  min-height: 100%;
+  cursor: pointer;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.category-card:focus,
+.category-card:hover {
+  transform: translateY(-8px);
+  box-shadow: var(--shadow-lg);
+}
+
+.category-card:focus {
+  outline: 3px solid rgba(226, 183, 20, 0.6);
+  outline-offset: 4px;
+}
+
+.category-card__icon svg {
+  width: 40px;
+  height: 40px;
+  color: var(--c-accent);
+}
+
+.category-card h3 {
+  margin: 0;
+  font-size: 1.3rem;
+  color: var(--c-primary);
+}
+
+.category-card__description {
+  margin: 0;
+  color: var(--c-muted);
+  flex-grow: 1;
+}
+
+.category-card__cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  color: var(--c-primary);
+}
+
+.category-card__cta::after {
+  content: '›';
+  font-size: 1.25rem;
+  line-height: 1;
+}
+
+.about {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  background: #fff;
+  border-radius: 1rem;
+  padding: 2.5rem 2rem;
+  border: 1px solid var(--c-border);
+  box-shadow: var(--shadow-sm);
+}
+
+.about-copy p {
+  margin: 0;
+  color: var(--c-muted);
+}
+
+.about-card {
+  background: var(--c-surface);
+  border-radius: 0.9rem;
+  padding: 2rem;
+  border: 1px solid var(--c-border);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.contact-link {
+  color: var(--c-primary);
+  font-weight: 600;
+}
+
+.game {
+  background: #fff;
+  border-radius: 1rem;
+  border: 1px solid var(--c-border);
+  box-shadow: var(--shadow-sm);
+  padding: 3rem 2rem;
+}
+
+.game-container {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  align-items: start;
+}
+
+.game-status p {
+  margin: 0 0 0.5rem;
+}
+
+.game-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.game-question {
+  background: var(--c-surface);
+  border-radius: 0.9rem;
+  padding: 1.75rem;
+  border: 1px solid var(--c-border);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.6);
+}
+
+.game-question h3 {
+  margin-top: 0;
+  color: var(--c-primary);
+}
+
+.game-options {
+  list-style: none;
+  margin: 1.25rem 0 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.game-option {
+  width: 100%;
+  border: 1px solid var(--c-border);
+  background: #fff;
+  color: var(--c-secondary);
+  border-radius: 0.75rem;
+  padding: 0.85rem 1.1rem;
+  font-weight: 600;
+  text-align: left;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.game-option:hover,
+.game-option:focus {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-sm);
+  border-color: rgba(11, 92, 94, 0.4);
+}
+
+.game-option--correct {
+  border-color: rgba(11, 92, 94, 0.7);
+  background: rgba(11, 92, 94, 0.08);
+}
+
+.game-option:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+  transform: none;
+  box-shadow: none;
+}
+
+.game-rules {
+  background: rgba(14, 42, 71, 0.06);
+  border-radius: 0.9rem;
+  padding: 1.75rem;
+  border: 1px dashed rgba(14, 42, 71, 0.2);
+}
+
+.game-rules h3 {
+  margin-top: 0;
+  color: var(--c-secondary);
+}
+
+.game-rules ol {
+  padding-left: 1.25rem;
+  margin: 0;
+  color: var(--c-muted);
+  display: grid;
+  gap: 0.5rem;
+}
+
+.article-wrap {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  color: var(--c-primary);
+}
+
+.back-link svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.article {
+  background: #fff;
+  border-radius: 1rem;
+  border: 1px solid var(--c-border);
+  padding: 2.5rem 2.25rem;
+  box-shadow: var(--shadow-sm);
+}
+
+.article h1 {
+  margin-top: 0;
+  color: var(--c-primary);
+}
+
+.article-meta {
+  color: var(--c-muted);
+  font-size: 0.95rem;
+  margin-bottom: 1.75rem;
+}
+
+.article-content {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.article-content ul,
+.article-content ol {
+  padding-left: 1.5rem;
+}
+
+.article-content blockquote {
+  margin: 0;
+  padding: 1.25rem 1.5rem;
+  border-left: 4px solid var(--c-accent);
+  background: rgba(226, 183, 20, 0.1);
+  color: var(--c-secondary);
+  font-style: italic;
+}
+
+.topics-list {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.topic-item {
+  background: #fff;
+  border-radius: 0.9rem;
+  border: 1px solid var(--c-border);
+  padding: 1.75rem;
+  box-shadow: var(--shadow-sm);
+}
+
+.topic-item h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.4rem;
+  color: var(--c-primary);
+}
+
+.topic-item__meta {
+  margin: 0 0 0.75rem;
+  color: var(--c-muted);
+  font-size: 0.9rem;
+}
+
+.topic-item p {
+  margin: 0;
+  color: var(--c-secondary);
+}
+
+.empty-state {
+  text-align: center;
+  background: var(--c-surface);
+  border-radius: 0.9rem;
+  padding: 2.5rem 2rem;
+  border: 1px solid var(--c-border);
+}
+
+.footer {
+  background: #f0f4f8;
+  border-top: 1px solid var(--c-border);
+  margin-top: 4rem;
+  padding: 2.5rem 0;
+  font-size: 0.95rem;
+}
+
+.footer-inner {
+  display: grid;
+  gap: 1rem;
+}
+
+.footer-contact,
+.footer-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem 1.5rem;
+}
+
+.footer-meta {
+  color: var(--c-muted);
+}
+
+.noscript {
+  max-width: 700px;
+  margin: 2rem auto;
+  padding: 1.5rem;
+  border-radius: 0.75rem;
+  background: rgba(226, 183, 20, 0.15);
+  color: var(--c-secondary);
+}
+
+@media (max-width: 900px) {
+  .nav-toggle {
+    display: inline-flex;
+  }
+
+  .nav-links {
+    position: absolute;
+    top: 100%;
+    right: 1.5rem;
+    background: #fff;
+    border: 1px solid var(--c-border);
+    border-radius: 0.75rem;
+    padding: 1rem 1.25rem;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+    box-shadow: var(--shadow-sm);
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(-10px);
+    transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease;
+  }
+
+  .nav-links--open {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+  }
+
+  .hero-inner {
+    flex-direction: column;
+    text-align: center;
+  }
+
+  .hero-highlight {
+    width: 100%;
+    align-items: center;
+  }
+
+  .cta-group {
+    justify-content: center;
+  }
+}
+
+@media (max-width: 640px) {
+  .category-card {
+    padding: 1.75rem 1.5rem;
+  }
+
+  .game {
+    padding: 2.25rem 1.5rem;
+  }
+
+  .article {
+    padding: 2rem 1.5rem;
+  }
+}


### PR DESCRIPTION
## Summary
- move the static blog from `docs/` into the repository root so GitHub Pages can publish without duplicate files that caused conflicts
- keep the existing hero, category grid, quiz and article templates while updating paths to the shared scripts/styles in their new locations
- refresh the README with the new project layout and local run instructions for the root-based structure

## Testing
- python -m http.server 8000
- curl -I http://127.0.0.1:8000/
- curl -I http://127.0.0.1:8000/category.html
- curl -I http://127.0.0.1:8000/post.html


------
https://chatgpt.com/codex/tasks/task_e_68d3c6a8501083308b80a2bd72679e75