### PR TITLE
Add Liga Przedsiębiorców standalone game page

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,7 @@ Po uruchomieniu wejdź na `http://localhost:8000/`.
 ## Struktura
 
 Cała zawartość serwisu znajduje się w katalogu `docs/`, co umożliwia bezpośrednie hostowanie w GitHub Pages (opcja *Deploy from branch* → `main` / `docs`).
+
+### Dodatkowe strony
+
+- `docs/liga-przedsiebiorcow.html` — samowystarczalna wersja gry "Liga Przedsiębiorców" z przechowywaniem stanu w `localStorage`. Do działania wymaga wyłącznie statycznego hostingu (np. GitHub Pages) i plików towarzyszących w katalogach `docs/styles/` oraz `docs/scripts/`.

--- a/docs/liga-przedsiebiorcow.html
+++ b/docs/liga-przedsiebiorcow.html
@@ -1,0 +1,283 @@
+<!doctype html>
+<html lang="pl" data-theme="dark">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Liga Przedsiębiorców 2.0 — Zbuduj swoje Imperium</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Nunito:wght@700;800;900&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles/liga.css" />
+  </head>
+  <body data-theme="dark">
+    <div id="auth-screen">
+      <h1 class="auth-title">Liga Przedsiębiorców</h1>
+      <div id="login-container" class="auth-container">
+        <h2>Logowanie</h2>
+        <div class="input-group">
+          <label for="login-username">Nazwa użytkownika</label>
+          <input id="login-username" type="text" class="auth-input" required />
+        </div>
+        <div class="input-group">
+          <label for="login-password">Hasło</label>
+          <input id="login-password" type="password" class="auth-input" required />
+        </div>
+        <button id="login-btn" class="auth-btn">Zaloguj się</button>
+        <p id="auth-error"></p>
+        <p id="auth-toggle">Nie masz konta? <b>Zarejestruj się</b></p>
+      </div>
+      <div id="register-container" class="auth-container hidden">
+        <h2>Rejestracja</h2>
+        <div class="input-group">
+          <label for="register-username">Nazwa użytkownika</label>
+          <input id="register-username" type="text" class="auth-input" required />
+        </div>
+        <div class="input-group">
+          <label for="register-password">Hasło</label>
+          <input id="register-password" type="password" class="auth-input" required />
+        </div>
+        <div class="input-group">
+          <label for="register-company">Nazwa firmy</label>
+          <input id="register-company" type="text" class="auth-input" required />
+        </div>
+        <button id="register-btn" class="auth-btn">Stwórz konto</button>
+        <p id="auth-error-reg"></p>
+        <p id="auth-toggle-login">Masz już konto? <b>Zaloguj się</b></p>
+      </div>
+    </div>
+
+    <div id="game-container" class="hidden">
+      <div class="wrap">
+        <aside class="sidebar">
+          <div class="brand card">
+            <svg
+              width="38"
+              height="38"
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M3 17l6-6 4 4 7-7"
+                stroke="#8ef0c0"
+                stroke-width="2.3"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+              <path
+                d="M21 10v7h-7"
+                stroke="#6ea8ff"
+                stroke-width="2.3"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+            <div>
+              <h1>Liga Przedsiębiorców</h1>
+              <div class="tag" id="companyNameTag"></div>
+            </div>
+          </div>
+          <nav class="card" style="padding: 16px; flex-grow: 1">
+            <a class="btn active" data-tab="imperium">🏛️ Imperium</a>
+            <a class="btn" data-tab="tech">🧠 Umysł Przedsiębiorcy</a>
+            <a class="btn" data-tab="market" id="market-nav-btn">📈 Giełda</a>
+            <a class="btn" data-tab="quests">🗓️ Zadania</a>
+            <a class="btn" data-tab="forum">🗣️ Głos Rynku</a>
+            <a class="btn" data-tab="shop">🛍️ Sklep</a>
+            <a class="btn" data-tab="ranking">🏆 Ranking</a>
+            <a class="btn" data-tab="settings">⚙️ Ustawienia</a>
+          </nav>
+          <div class="card" style="padding: 16px">
+            <div id="admin-login-btn-container">
+              <button class="btn btn-ghost" id="admin-login-btn" style="width: 100%">
+                Panel Admina
+              </button>
+            </div>
+            <div id="admin-panel-info" class="hidden" style="text-align: center">
+              <p>👑 Zalogowano jako <b>Admin</b></p>
+              <button class="btn" id="admin-add-btc">Dodaj 100 PW</button>
+            </div>
+          </div>
+        </aside>
+
+        <main class="content">
+          <section class="topbar">
+            <div class="kpi-grid">
+              <div class="kpi">
+                <h3>Stan konta</h3>
+                <div class="val" id="cash">$0</div>
+              </div>
+              <div class="kpi">
+                <h3>Przychód / s</h3>
+                <div class="val" id="ips">$0</div>
+              </div>
+              <div class="kpi">
+                <h3>PW</h3>
+                <div class="val" id="btc">0</div>
+              </div>
+            </div>
+            <div class="player-card">
+              <div class="player-info">
+                <h4 id="playerName">Gość</h4>
+                <div class="level">Poziom <span id="level-text">1</span></div>
+              </div>
+            </div>
+          </section>
+          <div class="xp-wrap">
+            <div style="display: flex; align-items: center; gap: 15px; width: 100%">
+              <div class="level-indicator"><span id="level">1</span></div>
+              <div class="progress"><i id="xpbar"></i></div>
+              <div style="text-align: right; font-size: 13px">
+                <span id="xp">0</span> / <span id="xpNext">100</span> XP
+              </div>
+            </div>
+          </div>
+
+          <div id="views-container">
+            <section class="section" data-view="imperium">
+              <h2>Twoje Imperium Biznesowe</h2>
+              <p class="sub">
+                Inwestuj w nowe firmy i ulepszaj istniejące, aby zdominować rynek. Każdy kolejny próg (25, 50, 100...) potraja zyski
+                firmy!
+              </p>
+              <div id="companies-grid"></div>
+              <div class="grid-2" style="margin-top: 18px">
+                <div class="card" style="padding: 20px">
+                  <h3>Bonusy Sektorowe</h3>
+                  <p class="sub" style="font-size: 13px">
+                    Posiadanie wszystkich firm z danego sektora odblokowuje potężne synergie i bonusy do zysków.
+                  </p>
+                  <div id="sectorStatus">—</div>
+                </div>
+                <div class="card" style="padding: 20px">
+                  <h3>Prestiż</h3>
+                  <p class="sub" style="font-size: 13px">
+                    Osiągnij 6 poziom, aby odblokować Prestiż. Zresetuj postęp firm za potężny, trwały mnożnik zysków i dostęp do
+                    Giełdy!
+                  </p>
+                  <button class="btn" id="prestigeBtn" disabled>🔁 Wykonaj Prestiż</button>
+                  <div id="prestigeInfo" style="margin-top: 10px; font-size: 13px"></div>
+                </div>
+              </div>
+            </section>
+
+            <section class="section hidden" data-view="tech">
+              <h2>Umysł Przedsiębiorcy</h2>
+              <p class="sub">
+                Wydawaj <b>PW (Punkty Wiedzy)</b> na trwałe ulepszenia, które zdefiniują Twoją strategię.
+              </p>
+              <div class="tree-grid" id="tech-tree-grid"></div>
+            </section>
+
+            <section class="section hidden" data-view="market">
+              <h2>Giełda: Wall Street Wirtualnych Wilków</h2>
+              <p class="sub">
+                Kursy zmieniają się co <b>5 minut</b>. Wiadomości z "Głosu Rynku" co <b>10 minut</b> mogą wywołać drastyczne wahania.
+                Inwestuj mądrze.
+              </p>
+              <div class="market-grid" id="market-grid"></div>
+              <div class="card" style="margin-top: 18px; padding: 20px">
+                <h3>Twoja Spółka na Giełdzie</h3>
+                <p class="sub" style="font-size: 13px">
+                  Wprowadź swoją firmę na giełdę, aby zdobyć kapitał od inwestorów. Wymaga <b>$100 000</b>.
+                </p>
+                <button class="btn" id="listCompanyBtn">Wprowadź spółkę na giełdę</button>
+              </div>
+              <div id="shareholder-panel-container"></div>
+            </section>
+
+            <section class="section hidden" data-view="quests">
+              <h2>Zadania Przedsiębiorcy</h2>
+              <p class="sub">
+                Wykonuj zadania, aby zdobywać cenne PW i punkty doświadczenia. Nowe zadania pojawiają się wraz z postępami w grze.
+              </p>
+              <div id="tasks-grid" style="display: grid; gap: 15px"></div>
+            </section>
+
+            <section class="section hidden" data-view="forum">
+              <h2>Głos Rynku</h2>
+              <p class="sub">
+                Śledź wiadomości rynkowe, aby przewidywać ruchy na giełdzie i komunikuj się z innymi graczami.
+              </p>
+              <div class="forum-container">
+                <div class="forum-feed-container">
+                  <div class="forum-tabs">
+                    <button class="forum-tab active" data-forum-tab="market">Giełda Wilków z Wall Street</button>
+                    <button class="forum-tab" data-forum-tab="general">Czat Ogólny</button>
+                  </div>
+                  <div class="forum-feed" id="forum-feed"></div>
+                </div>
+                <div class="post-form card">
+                  <h3>Napisz Post</h3>
+                  <p class="sub" style="font-size: 13px">Podziel się swoją opinią na czacie ogólnym.</p>
+                  <textarea id="post-text" placeholder="Twoja wiadomość..."></textarea>
+                  <button id="post-submit-btn" class="btn" style="margin-top: 10px; width: 100%">Opublikuj</button>
+                </div>
+              </div>
+            </section>
+
+            <section class="section hidden" data-view="shop">
+              <h2>Sklep</h2>
+              <p class="sub">
+                Inwestuj w narzędzia, które pomogą Ci spersonalizować swoje imperium i zyskać przewagę.
+              </p>
+              <div class="card" style="padding: 20px">
+                <h3>Agent AI do personalizacji</h3>
+                <p class="sub" style="font-size: 13px">
+                  Kup zaawansowanego agenta AI, aby odblokować możliwość zmiany swojego zdjęcia profilowego. Pokaż innym, kto tu rządzi!
+                </p>
+                <div id="ai-agent-shop">
+                  <p>Koszt: <b>$500 000</b></p>
+                  <button class="btn" id="buy-ai-agent-btn">Kup Agenta AI</button>
+                </div>
+                <div id="avatar-changer" class="hidden">
+                  <p>Wklej URL do nowego zdjęcia profilowego:</p>
+                  <input type="text" id="avatar-url-input" class="stock-input" placeholder="https://example.com/image.png" />
+                  <button id="save-avatar-btn" class="btn" style="margin-top: 10px">Zapisz Avatar</button>
+                </div>
+              </div>
+            </section>
+
+            <section class="section hidden" data-view="ranking">
+              <h2>Ranking Przedsiębiorców</h2>
+              <p class="sub">
+                Zobacz, jak wypadasz na tle innych graczy. Ranking oparty jest na całkowitej wartości netto.
+              </p>
+              <div id="leaderboard" class="card" style="padding: 20px"></div>
+            </section>
+
+            <section class="section hidden" data-view="settings">
+              <h2>Ustawienia</h2>
+              <p class="sub">Dostosuj grę do swoich preferencji i zarządzaj swoim kontem.</p>
+              <div class="settings-grid">
+                <div class="setting-card">
+                  <h3>Personalizacja</h3>
+                  <div class="switch">
+                    <label for="theme-toggle">Tryb Ciemny / Jasny</label>
+                    <input type="checkbox" id="theme-toggle" />
+                  </div>
+                </div>
+                <div class="setting-card">
+                  <h3>Konto</h3>
+                  <p>Zalogowano jako: <b id="settings-username"></b></p>
+                  <button id="logout-btn" class="btn btn-ghost">Wyloguj</button>
+                  <button id="wipe-btn" class="btn" style="background: var(--bad); margin-left: 10px">Usuń konto</button>
+                </div>
+                <div class="setting-card">
+                  <h3>Kontakt</h3>
+                  <p>Masz pytania lub sugestie? Skontaktuj się z deweloperem:</p>
+                  <a href="mailto:matyyes@wp.pl" style="color: var(--acc1)">matyyes@wp.pl</a>
+                </div>
+              </div>
+            </section>
+          </div>
+        </main>
+      </div>
+    </div>
+
+    <script src="scripts/liga.js" defer></script>
+  </body>
+</html>

--- a/docs/scripts/liga.js
+++ b/docs/scripts/liga.js
@@ -1,0 +1,1145 @@
+const Game = {
+  state: {},
+  eventsBound: false,
+  forumBinds: false,
+
+  init() {
+    this.cacheDOM();
+    this.bindAuthEvents();
+    this.checkLoggedIn();
+  },
+
+  cacheDOM() {
+    this.dom = {
+      authScreen: document.getElementById('auth-screen'),
+      loginContainer: document.getElementById('login-container'),
+      registerContainer: document.getElementById('register-container'),
+      authToggle: document.getElementById('auth-toggle'),
+      authToggleLogin: document.getElementById('auth-toggle-login'),
+      loginBtn: document.getElementById('login-btn'),
+      registerBtn: document.getElementById('register-btn'),
+      authError: document.getElementById('auth-error'),
+      authErrorReg: document.getElementById('auth-error-reg'),
+      gameContainer: document.getElementById('game-container'),
+      navButtons: document.querySelectorAll('nav .btn'),
+      views: {},
+    };
+
+    document.querySelectorAll('[data-view]').forEach((element) => {
+      this.dom.views[element.dataset.view] = element;
+    });
+  },
+
+  bindAuthEvents() {
+    this.dom.authToggle.addEventListener('click', () => this.toggleAuthForms(false));
+    this.dom.authToggleLogin.addEventListener('click', () => this.toggleAuthForms(true));
+    this.dom.loginBtn.addEventListener('click', () => this.handleLogin());
+    this.dom.registerBtn.addEventListener('click', () => this.handleRegister());
+  },
+
+  toggleAuthForms(showLogin) {
+    this.dom.loginContainer.classList.toggle('hidden', !showLogin);
+    this.dom.registerContainer.classList.toggle('hidden', showLogin);
+    this.dom.authError.textContent = '';
+    this.dom.authErrorReg.textContent = '';
+  },
+
+  getUsers() {
+    return JSON.parse(localStorage.getItem('lp_users') || '[]');
+  },
+
+  saveUsers(users) {
+    localStorage.setItem('lp_users', JSON.stringify(users));
+  },
+
+  handleLogin() {
+    const username = document.getElementById('login-username').value.trim();
+    const password = document.getElementById('login-password').value.trim();
+
+    if (!username || !password) {
+      this.dom.authError.textContent = 'Wszystkie pola są wymagane.';
+      return;
+    }
+
+    const users = this.getUsers();
+    const user = users.find((entry) => entry.username === username && entry.password === password);
+
+    if (user) {
+      localStorage.setItem('lp_currentUser', username);
+      this.startGame(user.data);
+    } else {
+      this.dom.authError.textContent = 'Nieprawidłowa nazwa lub hasło.';
+    }
+  },
+
+  handleRegister() {
+    const username = document.getElementById('register-username').value.trim();
+    const password = document.getElementById('register-password').value.trim();
+    const company = document.getElementById('register-company').value.trim();
+
+    if (!username || !password || !company) {
+      this.dom.authErrorReg.textContent = 'Wszystkie pola są wymagane.';
+      return;
+    }
+
+    const users = this.getUsers();
+    if (users.some((entry) => entry.username === username)) {
+      this.dom.authErrorReg.textContent = 'Ta nazwa użytkownika jest już zajęta.';
+      return;
+    }
+
+    const newUser = {
+      username,
+      password,
+      data: this.createInitialGameState(username, company),
+    };
+
+    users.push(newUser);
+    this.saveUsers(users);
+    localStorage.setItem('lp_currentUser', username);
+    this.startGame(newUser.data);
+  },
+
+  checkLoggedIn() {
+    const currentUsername = localStorage.getItem('lp_currentUser');
+    if (!currentUsername) {
+      return;
+    }
+
+    const users = this.getUsers();
+    const user = users.find((entry) => entry.username === currentUsername);
+    if (user) {
+      this.startGame(user.data);
+    }
+  },
+
+  startGame(stateData) {
+    this.state = JSON.parse(JSON.stringify(stateData));
+
+    this.initData();
+    this.applyTheme(this.state.preferences.theme);
+    this.updateAdminUI();
+    this.bindGameEvents();
+
+    this.dom.authScreen.classList.add('hidden');
+    this.dom.gameContainer.classList.remove('hidden');
+    requestAnimationFrame(() => {
+      this.dom.gameContainer.style.opacity = 1;
+    });
+
+    this.gameLoopInterval = setInterval(() => this.tick(), 100);
+    this.marketInterval = setInterval(() => this.tickMarket(false), 5 * 60 * 1000);
+    this.forumInterval = setInterval(() => this.tickMarket(true), 10 * 60 * 1000);
+
+    this.renderAll();
+  },
+
+  bindGameEvents() {
+    if (this.eventsBound) {
+      return;
+    }
+
+    this.dom.navButtons.forEach((button) => {
+      button.addEventListener('click', (event) => {
+        event.preventDefault();
+        if (!button.classList.contains('locked')) {
+          this.switchTab(button.dataset.tab);
+        }
+      });
+    });
+
+    document.getElementById('logout-btn').addEventListener('click', () => this.logout());
+    document.getElementById('wipe-btn').addEventListener('click', () => this.deleteAccount());
+    document.getElementById('theme-toggle').addEventListener('change', (event) => {
+      this.updateTheme(event.target.checked ? 'light' : 'dark');
+    });
+    document.getElementById('prestigeBtn').addEventListener('click', () => this.performPrestige());
+    document.getElementById('admin-login-btn').addEventListener('click', () => this.handleAdminLogin());
+    document.getElementById('admin-add-btc').addEventListener('click', () => {
+      this.state.btc += 100;
+      this.save();
+      this.renderTopBar();
+    });
+
+    this.eventsBound = true;
+  },
+
+  initData() {
+    const defaults = this.createInitialGameState(this.state.username, this.state.companyName);
+
+    this.state.market = {
+      ...defaults.market,
+      ...this.state.market,
+    };
+
+    const existingStocks = Array.isArray(this.state.market.stocks) ? this.state.market.stocks : [];
+    this.state.market.stocks = defaults.market.stocks.map((stock) => ({
+      ...stock,
+      ...existingStocks.find((item) => item.id === stock.id),
+    }));
+
+    const existingCompanies = Array.isArray(this.state.companies) ? this.state.companies : [];
+    this.state.companies = defaults.companies.map((company) => ({
+      ...company,
+      ...existingCompanies.find((item) => item.id === company.id),
+    }));
+
+    this.state.forum = {
+      market: this.state.forum?.market ?? defaults.forum.market,
+      general: this.state.forum?.general ?? defaults.forum.general,
+    };
+
+    this.state.quests = Array.isArray(this.state.quests) ? this.state.quests : defaults.quests;
+    this.state.shop = { ...defaults.shop, ...this.state.shop };
+    this.state.totals = { ...defaults.totals, ...this.state.totals };
+
+    if (!this.state.tech) {
+      this.state.tech = defaults.tech;
+    } else {
+      for (const branchKey of Object.keys(defaults.tech)) {
+        if (!this.state.tech[branchKey]) {
+          this.state.tech[branchKey] = defaults.tech[branchKey];
+          continue;
+        }
+
+        const existingUpgrades = Array.isArray(this.state.tech[branchKey].upgrades)
+          ? this.state.tech[branchKey].upgrades
+          : [];
+        this.state.tech[branchKey].upgrades = defaults.tech[branchKey].upgrades.map((upgrade) => ({
+          ...upgrade,
+          ...existingUpgrades.find((item) => item.id === upgrade.id),
+        }));
+      }
+    }
+
+    this.state.preferences = {
+      ...defaults.preferences,
+      ...this.state.preferences,
+    };
+
+    if (typeof this.state.btc !== 'number') {
+      this.state.btc = defaults.btc;
+    }
+
+    if (!this.state.market.playerListed) {
+      this.state.market.playerListed = false;
+    }
+
+    if (typeof this.state.admin !== 'boolean') {
+      this.state.admin = false;
+    }
+
+    if (!this.state.lastTick) {
+      this.state.lastTick = Date.now();
+    }
+
+    this.save();
+  },
+
+  tick() {
+    const now = Date.now();
+    const dt = (now - (this.state.lastTick || now)) / 1000;
+    this.state.lastTick = now;
+
+    this.state.cash += this.calculateIPS() * dt;
+
+    this.checkQuests();
+    this.renderTopBar();
+  },
+
+  save() {
+    const currentUsername = localStorage.getItem('lp_currentUser');
+    if (!currentUsername) {
+      return;
+    }
+
+    const users = this.getUsers();
+    const userIndex = users.findIndex((entry) => entry.username === currentUsername);
+    if (userIndex > -1) {
+      users[userIndex].data = this.state;
+      this.saveUsers(users);
+    }
+  },
+
+  renderAll() {
+    this.switchTab('imperium');
+  },
+
+  renderTopBar() {
+    document.getElementById('cash').textContent = this.formatCurrency(this.state.cash);
+    document.getElementById('ips').textContent = this.formatCurrency(this.calculateIPS());
+    document.getElementById('btc').textContent = this.state.btc.toLocaleString();
+    document.getElementById('playerName').textContent = this.state.username;
+    document.getElementById('companyNameTag').textContent = this.state.companyName;
+    document.getElementById('level').textContent = this.state.level;
+    document.getElementById('level-text').textContent = this.state.level;
+    document.getElementById('xp').textContent = Math.floor(this.state.xp);
+    document.getElementById('xpNext').textContent = this.state.xpNext;
+
+    const xpProgress = this.state.xpNext > 0 ? Math.min(this.state.xp / this.state.xpNext, 1) : 0;
+    document.getElementById('xpbar').style.transform = `scaleX(${xpProgress})`;
+  },
+
+  renderNav() {
+    const marketNavBtn = document.getElementById('market-nav-btn');
+    if (this.state.market.unlocked) {
+      marketNavBtn.classList.remove('locked');
+      marketNavBtn.removeAttribute('title');
+    } else {
+      marketNavBtn.classList.add('locked');
+      marketNavBtn.title = 'Odblokuj po pierwszym prestiżu';
+    }
+  },
+
+  switchTab(tabId) {
+    this.dom.navButtons.forEach((button) => button.classList.remove('active'));
+    const activeButton = document.querySelector(`nav .btn[data-tab="${tabId}"]`);
+    if (activeButton) {
+      activeButton.classList.add('active');
+    }
+
+    Object.values(this.dom.views).forEach((view) => view.classList.add('hidden'));
+    if (this.dom.views[tabId]) {
+      this.dom.views[tabId].classList.remove('hidden');
+    }
+
+    this.renderTopBar();
+    this.renderNav();
+
+    switch (tabId) {
+      case 'imperium':
+        this.renderImperium();
+        break;
+      case 'tech':
+        this.renderTech();
+        break;
+      case 'market':
+        this.renderMarket();
+        break;
+      case 'quests':
+        this.renderQuests();
+        break;
+      case 'forum':
+        this.renderForum();
+        break;
+      case 'shop':
+        this.renderShop();
+        break;
+      case 'ranking':
+        this.renderRanking();
+        break;
+      case 'settings':
+        this.renderSettings();
+        break;
+      default:
+        break;
+    }
+  },
+
+  createInitialGameState(username, companyName) {
+    return {
+      username,
+      companyName,
+      level: 1,
+      xp: 0,
+      xpNext: 100,
+      cash: 1000,
+      btc: 0,
+      avatar: `https://placehold.co/100x100/1b213b/e0e8ff?text=${username.charAt(0).toUpperCase()}`,
+      companies: [
+        { id: 'startup', name: 'Garażowy Startup IT', sector: 'IT', base: 5, level: 1, desc: 'Skromny początek w świecie kodu.' },
+        { id: 'cafe', name: 'Kawiarnia "Pixel Cafe"', sector: 'Usługi', base: 80, level: 0, desc: 'Lokalny biznes dla nerdów i nie tylko.' },
+        { id: 'soft', name: 'Software House', sector: 'IT', base: 600, level: 0, desc: 'Tworzenie oprogramowania na zlecenie.' },
+        { id: 'fab3d', name: 'Fabryka Drukarek 3D', sector: 'Przemysł', base: 5000, level: 0, desc: 'Wejście na rynek produkcyjny.' },
+        { id: 'global', name: 'Globalna Korporacja Tech', sector: 'IT', base: 25000, level: 0, desc: 'Dominacja na rynku światowym.' },
+      ],
+      tech: {
+        innowacje: {
+          name: 'Gałąź Innowacji',
+          upgrades: [
+            { id: 'innowacje1', name: 'Kreatywne Myślenie', desc: '+5% do globalnych zysków', cost: 5, level: 0 },
+            { id: 'innowacje2', name: 'Badania i Rozwój', desc: '-10% koszt ulepszeń firm', cost: 10, level: 0 },
+          ],
+        },
+        marketing: {
+          name: 'Gałąź Marketingu',
+          upgrades: [
+            { id: 'marketing1', name: 'Marketing Szeptany', desc: '+15% zysków dla 2 pierwszych firm', cost: 5, level: 0 },
+            { id: 'marketing2', name: 'Analityka Rynku', desc: 'Częstsze i trafniejsze wskazówki na forum', cost: 15, level: 0 },
+          ],
+        },
+        finanse: {
+          name: 'Gałąź Finansów',
+          upgrades: [
+            { id: 'finanse1', name: 'Twarde Negocjacje', desc: '-10% koszt zakupu firm', cost: 8, level: 0 },
+            { id: 'finanse2', name: 'Dywersyfikacja Portfela', desc: 'Zmniejsza prowizję giełdową o 20%', cost: 20, level: 0 },
+          ],
+        },
+      },
+      market: {
+        unlocked: false,
+        fee: 0.01,
+        stocks: [
+          { id: 'CYBR', name: 'CybeRaptor Inc.', price: 150, lastPrice: 150, volatility: 0.15, owned: 0, totalShares: 10000 },
+          { id: 'ECOV', name: 'EcoVolt S.A.', price: 80, lastPrice: 80, volatility: 0.05, owned: 0, totalShares: 20000 },
+          { id: 'BIOG', name: 'BioGenetiCorp', price: 50, lastPrice: 50, volatility: 0.25, owned: 0, totalShares: 5000 },
+          { id: 'QLG', name: 'QuantumLeap Games', price: 65, lastPrice: 65, volatility: 0.18, owned: 0, totalShares: 15000 },
+        ],
+        playerListed: false,
+      },
+      forum: {
+        market: [
+          {
+            text: 'Witaj na Giełdzie Wilków z Wall Street! Obserwuj ten kanał, aby podejmować trafne decyzje.',
+            author: 'System',
+            timestamp: Date.now(),
+          },
+        ],
+        general: [
+          {
+            text: 'Witaj na czacie ogólnym! Porozmawiaj z innymi przedsiębiorcami.',
+            author: 'System',
+            timestamp: Date.now(),
+          },
+        ],
+      },
+      quests: this.generateQuests(),
+      totals: { prestige: 0 },
+      shop: { aiAgent: false },
+      lastTick: Date.now(),
+      admin: false,
+      preferences: {
+        theme: 'dark',
+      },
+    };
+  },
+
+  hasUpgrade(state, branchKey, upgradeId) {
+    const branch = state?.tech?.[branchKey];
+    if (!branch || !Array.isArray(branch.upgrades)) {
+      return false;
+    }
+
+    const upgrade = branch.upgrades.find((item) => item.id === upgradeId);
+    return Boolean(upgrade && upgrade.level > 0);
+  },
+
+  calculateCompanyIncome(company) {
+    if (!company || company.level <= 0) {
+      return 0;
+    }
+
+    let income = company.base * company.level;
+    [25, 50, 100, 200, 400, 800].forEach((threshold) => {
+      if (company.level >= threshold) {
+        income *= 3;
+      }
+    });
+
+    if (this.hasUpgrade(this.state, 'innowacje', 'innowacje1')) {
+      income *= 1.05;
+    }
+
+    let marketingBonus = 0;
+    if (this.hasUpgrade(this.state, 'marketing', 'marketing1')) {
+      const boostedIds = this.state.companies.slice(0, 2).map((c) => c.id);
+      if (boostedIds.includes(company.id)) {
+        marketingBonus = company.base * company.level * 0.15;
+      }
+    }
+
+    const prestigeMultiplier = 1 + (this.state.totals?.prestige ?? 0) * 0.1;
+    return (income + marketingBonus) * prestigeMultiplier;
+  },
+
+  calculateIPS() {
+    if (!Array.isArray(this.state.companies)) {
+      return 0;
+    }
+
+    return this.state.companies.reduce((total, company) => total + this.calculateCompanyIncome(company), 0);
+  },
+
+  calculateUpgradeCost(company, state = this.state) {
+    if (!company) {
+      return 0;
+    }
+
+    let baseCost = company.base * 20 * Math.pow(1.18, company.level);
+    if (this.hasUpgrade(state, 'innowacje', 'innowacje2')) {
+      baseCost *= 0.9;
+    }
+    return baseCost;
+  },
+
+  buyCompanyLevel(companyId) {
+    const company = this.state.companies.find((entry) => entry.id === companyId);
+    if (!company) {
+      return;
+    }
+
+    const cost = this.calculateUpgradeCost(company);
+    if (this.state.cash >= cost) {
+      this.state.cash -= cost;
+      company.level += 1;
+      this.addXP(50);
+      this.renderImperium();
+      this.save();
+    }
+  },
+
+  buyCompany(companyId) {
+    const company = this.state.companies.find((entry) => entry.id === companyId);
+    if (!company || company.level > 0) {
+      return;
+    }
+
+    let cost = company.base * 15;
+    if (this.hasUpgrade(this.state, 'finanse', 'finanse1')) {
+      cost *= 0.9;
+    }
+
+    if (this.state.cash >= cost) {
+      this.state.cash -= cost;
+      company.level = 1;
+      this.addXP(100);
+      this.renderImperium();
+      this.save();
+    }
+  },
+
+  addXP(amount) {
+    this.state.xp += amount;
+    while (this.state.xp >= this.state.xpNext) {
+      this.state.xp -= this.state.xpNext;
+      this.state.level += 1;
+      this.state.xpNext = Math.floor(this.state.xpNext * 1.5);
+    }
+
+    if (this.state.level >= 6) {
+      document.getElementById('prestigeBtn').disabled = false;
+    }
+  },
+
+  performPrestige() {
+    if (this.state.level < 6) {
+      return;
+    }
+
+    if (
+      confirm(
+        'Czy na pewno chcesz wykonać prestiż? Zresetujesz firmy i gotówkę, ale zyskasz trwały bonus +10% do zysków i odblokujesz Giełdę!'
+      )
+    ) {
+      this.state.totals.prestige += 1;
+      this.state.cash = 1000;
+      this.state.market.unlocked = true;
+      this.state.companies.forEach((company, index) => {
+        company.level = index === 0 ? 1 : 0;
+      });
+      this.switchTab('imperium');
+      this.save();
+    }
+  },
+
+  renderImperium() {
+    const grid = document.getElementById('companies-grid');
+    grid.innerHTML = '';
+
+    this.state.companies.forEach((company) => {
+      const card = document.createElement('div');
+      card.className = 'company-card';
+
+      if (company.level > 0) {
+        const upgradeCost = this.calculateUpgradeCost(company);
+        const income = this.calculateCompanyIncome(company);
+
+        const thresholds = [25, 50, 100, 200, 400, 800];
+        const nextThreshold = thresholds.find((threshold) => company.level < threshold);
+        card.innerHTML = `
+          <div class="company-card-header">
+            <h4>${company.name}</h4>
+            <span class="pill">Poziom ${company.level}</span>
+          </div>
+          <p class="sub" style="font-size: 13px; margin: 0;">${company.desc}</p>
+          <div class="company-stats">
+            <div>Zysk / s: <b class="mono">${this.formatCurrency(income)}</b></div>
+            <div>Następny próg: <b class="mono">${nextThreshold ? `Lvl ${nextThreshold}` : 'Maks.'}</b></div>
+          </div>
+          <p>Koszt ulepszenia: <b class="mono">${this.formatCurrency(upgradeCost)}</b></p>
+          <button class="btn" data-company-upgrade="${company.id}" ${this.state.cash < upgradeCost ? 'disabled' : ''}>Ulepsz</button>
+        `;
+      } else {
+        let purchaseCost = company.base * 15;
+        if (this.hasUpgrade(this.state, 'finanse', 'finanse1')) {
+          purchaseCost *= 0.9;
+        }
+
+        card.innerHTML = `
+          <div class="company-card-header">
+            <h4>${company.name}</h4>
+            <span class="pill">Zablokowane</span>
+          </div>
+          <p class="sub" style="font-size: 13px; margin: 0;">${company.desc}</p>
+          <p>Koszt zakupu: <b class="mono">${this.formatCurrency(purchaseCost)}</b></p>
+          <button class="btn" data-company-buy="${company.id}" ${this.state.cash < purchaseCost ? 'disabled' : ''}>Kup firmę</button>
+        `;
+      }
+
+      grid.appendChild(card);
+    });
+
+    grid.querySelectorAll('[data-company-upgrade]').forEach((button) => {
+      button.addEventListener('click', () => this.buyCompanyLevel(button.dataset.companyUpgrade));
+    });
+    grid.querySelectorAll('[data-company-buy]').forEach((button) => {
+      button.addEventListener('click', () => this.buyCompany(button.dataset.companyBuy));
+    });
+
+    document.getElementById('prestigeBtn').disabled = this.state.level < 6;
+    document.getElementById(
+      'prestigeInfo'
+    ).textContent = `Wykonanych prestiży: ${this.state.totals.prestige} (Bonus: +${this.state.totals.prestige * 10}%)`;
+  },
+
+  renderTech() {
+    const grid = document.getElementById('tech-tree-grid');
+    grid.innerHTML = '';
+
+    Object.entries(this.state.tech).forEach(([branchKey, branch]) => {
+      const branchDiv = document.createElement('div');
+      branchDiv.className = 'tech-branch';
+      branchDiv.innerHTML = `<h3>${branch.name}</h3>`;
+
+      (branch.upgrades || []).forEach((upgrade) => {
+        const item = document.createElement('div');
+        item.className = 'tech-item';
+        const isPurchased = upgrade.level > 0;
+        const canAfford = this.state.btc >= upgrade.cost;
+
+        item.innerHTML = `
+          <b>${upgrade.name}</b>
+          <small>${upgrade.desc}</small>
+          <small>Koszt: ${upgrade.cost} PW</small>
+          <button class="btn btn-ghost" data-tech-buy="${branchKey}:${upgrade.id}" ${
+            isPurchased || !canAfford ? 'disabled' : ''
+          }>${isPurchased ? 'Wykupione' : 'Kup'}</button>
+        `;
+
+        branchDiv.appendChild(item);
+      });
+
+      grid.appendChild(branchDiv);
+    });
+
+    grid.querySelectorAll('[data-tech-buy]').forEach((button) => {
+      button.addEventListener('click', () => {
+        const [branchKey, upgradeId] = button.dataset.techBuy.split(':');
+        const upgrade = this.state.tech[branchKey].upgrades.find((entry) => entry.id === upgradeId);
+        if (upgrade && upgrade.level === 0 && this.state.btc >= upgrade.cost) {
+          this.state.btc -= upgrade.cost;
+          upgrade.level = 1;
+          this.renderTech();
+          this.renderTopBar();
+          this.save();
+        }
+      });
+    });
+  },
+
+  renderMarket() {
+    const grid = document.getElementById('market-grid');
+    grid.innerHTML = '';
+
+    const stocks = this.state.market.playerListed
+      ? [...this.state.market.stocks, this.getPlayerStock()]
+      : [...this.state.market.stocks];
+
+    stocks.forEach((stock) => {
+      const change = stock.price - stock.lastPrice;
+      const changePct = stock.lastPrice > 0 ? (change / stock.lastPrice) * 100 : 0;
+      const stockDiv = document.createElement('div');
+      stockDiv.className = 'stock';
+      stockDiv.innerHTML = `
+        <div class="row"><b>${stock.name}</b><span class="pill">${stock.id}</span></div>
+        <div class="row">
+          <div class="price">${this.formatCurrency(stock.price, 2)}</div>
+          <div class="trend ${change >= 0 ? 'up' : 'down'}">${change >= 0 ? '▲' : '▼'} ${changePct.toFixed(2)}%</div>
+        </div>
+        <p class="sub" style="font-size: 12px;">Posiadane: ${stock.owned.toLocaleString()} akcji</p>
+        <div class="row" style="gap: 5px;">
+          <input type="number" class="stock-input" id="input-${stock.id}" min="1" value="1" />
+          <button class="btn" data-market-buy="${stock.id}">Kup</button>
+          <button class="btn btn-ghost" data-market-sell="${stock.id}">Sprzedaj</button>
+        </div>
+      `;
+      grid.appendChild(stockDiv);
+    });
+
+    grid.querySelectorAll('[data-market-buy]').forEach((button) =>
+      button.addEventListener('click', () => this.tradeStock(button.dataset.marketBuy, 'buy'))
+    );
+    grid.querySelectorAll('[data-market-sell]').forEach((button) =>
+      button.addEventListener('click', () => this.tradeStock(button.dataset.marketSell, 'sell'))
+    );
+
+    const listBtn = document.getElementById('listCompanyBtn');
+    listBtn.disabled = this.state.cash < 100000 || this.state.market.playerListed;
+    listBtn.textContent = this.state.market.playerListed ? 'Twoja firma jest na giełdzie' : 'Wprowadź spółkę na giełdę';
+    listBtn.onclick = () => {
+      if (this.state.cash >= 100000 && !this.state.market.playerListed) {
+        this.state.cash -= 100000;
+        this.state.market.playerListed = true;
+        this.addXP(1000);
+        this.renderMarket();
+        this.renderTopBar();
+        this.save();
+      }
+    };
+
+    this.renderShareholderPanel();
+  },
+
+  renderShareholderPanel() {
+    const container = document.getElementById('shareholder-panel-container');
+    container.innerHTML = '';
+
+    this.state.market.stocks.forEach((stock) => {
+      if (stock.totalShares > 0 && stock.owned / stock.totalShares > 0.5) {
+        const panel = document.createElement('div');
+        panel.className = 'card';
+        panel.style.cssText = 'margin-top: 18px; padding: 20px;';
+        panel.innerHTML = `
+          <h3>Panel Decyzyjny: ${stock.name}</h3>
+          <p class="sub">Masz większość udziałów! Twoje decyzje wpłyną na kurs akcji.</p>
+          <button class="btn" data-decision="${stock.id}:agressive">Agresywna kampania (+cena, +ryzyko)</button>
+          <button class="btn btn-ghost" data-decision="${stock.id}:stable" style="margin-left: 10px;">Stabilny rozwój (+cena, -ryzyko)</button>
+        `;
+        container.appendChild(panel);
+      }
+    });
+
+    container.querySelectorAll('[data-decision]').forEach((button) => {
+      button.addEventListener('click', () => {
+        const [stockId, decision] = button.dataset.decision.split(':');
+        const stock = this.state.market.stocks.find((entry) => entry.id === stockId);
+        if (!stock) {
+          return;
+        }
+
+        if (decision === 'agressive') {
+          stock.price *= 1 + (Math.random() * 0.4 - 0.1);
+        } else {
+          stock.price *= 1 + (Math.random() * 0.1 + 0.05);
+        }
+
+        stock.price = Math.max(1, stock.price);
+        alert(`Decyzja podjęta! Nowa cena ${stock.name} to ${this.formatCurrency(stock.price, 2)}`);
+        this.renderMarket();
+        this.save();
+      });
+    });
+  },
+
+  getPlayerStock() {
+    if (!this.state.market.playerStock) {
+      this.state.market.playerStock = {
+        id: 'PLAYER',
+        name: this.state.companyName,
+        price: 20,
+        lastPrice: 20,
+        volatility: 0.1,
+        owned: 0,
+        totalShares: 50000,
+      };
+    }
+
+    const stock = this.state.market.playerStock;
+    stock.lastPrice = stock.price;
+    stock.price = 20 + Math.log10(this.calculateIPS() + 1) * 10;
+    return stock;
+  },
+
+  tradeStock(stockId, type) {
+    const stock = stockId === 'PLAYER'
+      ? this.getPlayerStock()
+      : this.state.market.stocks.find((entry) => entry.id === stockId);
+
+    if (!stock) {
+      return;
+    }
+
+    const amountInput = document.getElementById(`input-${stock.id}`);
+    const amount = parseInt(amountInput?.value, 10);
+    if (!Number.isFinite(amount) || amount <= 0) {
+      return;
+    }
+
+    const cost = stock.price * amount;
+    const feeMultiplier = this.hasUpgrade(this.state, 'finanse', 'finanse2') ? 0.8 : 1;
+    const fee = cost * this.state.market.fee * feeMultiplier;
+
+    if (type === 'buy' && this.state.cash >= cost + fee) {
+      this.state.cash -= cost + fee;
+      stock.owned += amount;
+    } else if (type === 'sell' && stock.owned >= amount) {
+      this.state.cash += cost - fee;
+      stock.owned -= amount;
+    }
+
+    this.renderMarket();
+    this.renderTopBar();
+    this.save();
+  },
+
+  tickMarket(isMajorEvent) {
+    if (!this.state.market || !Array.isArray(this.state.market.stocks)) {
+      return;
+    }
+
+    this.state.market.stocks.forEach((stock) => {
+      stock.lastPrice = stock.price;
+      stock.price *= 1 + (Math.random() * 2 - 1) * stock.volatility;
+      stock.price = Math.max(1, stock.price);
+    });
+
+    if (isMajorEvent) {
+      const randomStock = this.state.market.stocks[Math.floor(Math.random() * this.state.market.stocks.length)];
+      const majorChange = Math.random() * 0.7 - 0.3;
+      randomStock.price *= 1 + majorChange;
+      randomStock.price = Math.max(1, randomStock.price);
+      const message =
+        majorChange > 0
+          ? `Pozytywne prognozy dla ${randomStock.name}! Analitycy przewidują gwałtowny wzrost.`
+          : `Niepokojące wieści z ${randomStock.name}. Inwestorzy w panice wyprzedają akcje.`;
+      this.addForumPost('market', message, 'Analityk Rynku');
+    }
+
+    if (this.state.market.playerListed) {
+      const playerStock = this.getPlayerStock();
+      this.state.market.playerStock = playerStock;
+    }
+
+    if (document.querySelector('.btn.active[data-tab="market"]')) {
+      this.renderMarket();
+    }
+
+    this.save();
+  },
+
+  calculatePortfolioValue(state = this.state) {
+    const baseStocksValue = (state.market?.stocks || []).reduce((acc, stock) => acc + stock.owned * stock.price, 0);
+    const playerStockValue = state.market?.playerListed ? (state.market.playerStock?.owned || 0) * (state.market.playerStock?.price || 0) : 0;
+    return baseStocksValue + playerStockValue;
+  },
+
+  generateQuests() {
+    return [
+      { id: 1, name: 'Pierwszy krok', desc: 'Osiągnij 2 poziom', goal: { type: 'level', value: 2 }, reward: { xp: 100, btc: 5 }, claimed: false },
+      { id: 2, name: 'Mały kapitalista', desc: 'Zgromadź $10 000', goal: { type: 'cash', value: 10000 }, reward: { xp: 150, btc: 10 }, claimed: false },
+      { id: 3, name: 'Rozwój imperium', desc: 'Posiadaj 3 firmy', goal: { type: 'companies', value: 3 }, reward: { xp: 200, btc: 15 }, claimed: false },
+      { id: 4, name: 'Młody Inwestor', desc: 'Kup pierwsze akcje na giełdzie', goal: { type: 'stocks', value: 1 }, reward: { xp: 500, btc: 20 }, claimed: false },
+    ];
+  },
+
+  checkQuests() {
+    if (!Array.isArray(this.state.quests)) {
+      return;
+    }
+
+    this.state.quests.forEach((quest) => {
+      if (quest.claimed || quest.completed) {
+        return;
+      }
+
+      let progress = false;
+      switch (quest.goal.type) {
+        case 'level':
+          progress = this.state.level >= quest.goal.value;
+          break;
+        case 'cash':
+          progress = this.state.cash >= quest.goal.value;
+          break;
+        case 'companies':
+          progress = this.state.companies.filter((company) => company.level > 0).length >= quest.goal.value;
+          break;
+        case 'stocks': {
+          const ownsMarketStock = this.state.market.stocks.some((stock) => stock.owned > 0);
+          const ownsPlayerStock = (this.state.market.playerStock?.owned || 0) > 0;
+          progress = ownsMarketStock || ownsPlayerStock;
+          break;
+        }
+        default:
+          break;
+      }
+
+      if (progress) {
+        quest.completed = true;
+      }
+    });
+  },
+
+  renderQuests() {
+    const grid = document.getElementById('tasks-grid');
+    grid.innerHTML = '';
+
+    if (!Array.isArray(this.state.quests)) {
+      return;
+    }
+
+    this.state.quests.forEach((quest) => {
+      const taskDiv = document.createElement('div');
+      taskDiv.className = 'card';
+      taskDiv.style.padding = '15px';
+      taskDiv.innerHTML = `
+        <h4>${quest.name}</h4>
+        <p class="sub" style="font-size: 13px;">${quest.desc}</p>
+        <p>Nagroda: ${quest.reward.xp} XP, ${quest.reward.btc} PW</p>
+        <button class="btn" data-quest-claim="${quest.id}" ${!quest.completed || quest.claimed ? 'disabled' : ''}>
+          ${quest.claimed ? 'Odebrano' : quest.completed ? 'Odbierz' : 'W toku'}
+        </button>
+      `;
+      grid.appendChild(taskDiv);
+    });
+
+    grid.querySelectorAll('[data-quest-claim]').forEach((button) => {
+      button.addEventListener('click', () => {
+        const quest = this.state.quests.find((entry) => entry.id === Number(button.dataset.questClaim));
+        if (quest && quest.completed && !quest.claimed) {
+          this.addXP(quest.reward.xp);
+          this.state.btc += quest.reward.btc;
+          quest.claimed = true;
+          this.renderQuests();
+          this.save();
+        }
+      });
+    });
+  },
+
+  addForumPost(channel, text, author) {
+    if (!this.state.forum[channel]) {
+      this.state.forum[channel] = [];
+    }
+
+    this.state.forum[channel].unshift({ text, author, timestamp: Date.now() });
+    if (this.state.forum[channel].length > 50) {
+      this.state.forum[channel].pop();
+    }
+
+    if (document.querySelector('.btn.active[data-tab="forum"]')) {
+      this.renderForum();
+    }
+  },
+
+  renderForum() {
+    const feed = document.getElementById('forum-feed');
+    const activeTab = document.querySelector('.forum-tab.active');
+    const activeChannel = activeTab ? activeTab.dataset.forumTab : 'market';
+    const posts = this.state.forum[activeChannel] || [];
+
+    feed.innerHTML = posts
+      .map(
+        (post) => `
+        <div class="post">
+          <div class="post-header">[${new Date(post.timestamp).toLocaleTimeString()}] <b>${post.author}</b> napisał:</div>
+          <div class="post-content">${post.text}</div>
+        </div>
+      `
+      )
+      .join('');
+
+    if (!this.forumBinds) {
+      document.querySelectorAll('.forum-tab').forEach((tab) => {
+        tab.addEventListener('click', () => {
+          document.querySelector('.forum-tab.active').classList.remove('active');
+          tab.classList.add('active');
+          this.renderForum();
+        });
+      });
+
+      document.getElementById('post-submit-btn').addEventListener('click', () => {
+        const textarea = document.getElementById('post-text');
+        const text = textarea.value.trim();
+        if (text) {
+          this.addForumPost('general', text, this.state.username);
+          textarea.value = '';
+          this.save();
+        }
+      });
+
+      this.forumBinds = true;
+    }
+  },
+
+  renderShop() {
+    const agentShop = document.getElementById('ai-agent-shop');
+    const avatarChanger = document.getElementById('avatar-changer');
+    const buyBtn = document.getElementById('buy-ai-agent-btn');
+    const saveAvatarBtn = document.getElementById('save-avatar-btn');
+
+    if (this.state.shop.aiAgent) {
+      agentShop.classList.add('hidden');
+      avatarChanger.classList.remove('hidden');
+    } else {
+      agentShop.classList.remove('hidden');
+      avatarChanger.classList.add('hidden');
+      buyBtn.disabled = this.state.cash < 500000;
+    }
+
+    buyBtn.onclick = () => {
+      if (this.state.cash >= 500000 && !this.state.shop.aiAgent) {
+        this.state.cash -= 500000;
+        this.state.shop.aiAgent = true;
+        this.renderShop();
+        this.renderTopBar();
+        this.save();
+      }
+    };
+
+    saveAvatarBtn.onclick = () => {
+      const url = document.getElementById('avatar-url-input').value.trim();
+      if (url) {
+        this.state.avatar = url;
+        this.renderTopBar();
+        this.save();
+      }
+    };
+  },
+
+  renderRanking() {
+    const leaderboard = document.getElementById('leaderboard');
+    const users = this.getUsers()
+      .map((entry) => ({
+        name: entry.username,
+        netWorth: this.calculateNetWorth(entry.data),
+      }))
+      .sort((a, b) => b.netWorth - a.netWorth);
+
+    leaderboard.innerHTML = users
+      .map(
+        (user, index) => `
+        <div class="row" style="padding: 8px 0; border-bottom: 1px solid var(--border);">
+          <span><b>#${index + 1}</b> ${user.name}</span>
+          <span class="mono">${this.formatCurrency(user.netWorth)}</span>
+        </div>
+      `
+      )
+      .join('');
+  },
+
+  calculateNetWorth(data) {
+    if (!data) {
+      return 0;
+    }
+
+    const cash = data.cash || 0;
+    const portfolioValue = this.calculatePortfolioValue(data);
+    const companiesValue = (data.companies || []).reduce((acc, company) => {
+      if (company.level <= 0) {
+        return acc;
+      }
+      return acc + this.calculateUpgradeCost(company, data) * company.level;
+    }, 0);
+
+    return cash + portfolioValue + companiesValue;
+  },
+
+  renderSettings() {
+    document.getElementById('settings-username').textContent = this.state.username;
+    document.getElementById('theme-toggle').checked = this.state.preferences.theme === 'light';
+  },
+
+  updateAdminUI() {
+    const loginContainer = document.getElementById('admin-login-btn-container');
+    const infoContainer = document.getElementById('admin-panel-info');
+    if (!loginContainer || !infoContainer) {
+      return;
+    }
+
+    if (this.state.admin) {
+      loginContainer.classList.add('hidden');
+      infoContainer.classList.remove('hidden');
+    } else {
+      loginContainer.classList.remove('hidden');
+      infoContainer.classList.add('hidden');
+    }
+  },
+
+  updateTheme(theme) {
+    this.state.preferences.theme = theme;
+    this.applyTheme(theme);
+    this.save();
+  },
+
+  applyTheme(theme) {
+    document.body.dataset.theme = theme;
+    document.documentElement.dataset.theme = theme;
+    const toggle = document.getElementById('theme-toggle');
+    if (toggle) {
+      toggle.checked = theme === 'light';
+    }
+  },
+
+  handleAdminLogin() {
+    const pass = prompt('Podaj hasło administratora:');
+    if (pass === 'liga10078933') {
+      this.state.admin = true;
+      alert('Zalogowano jako administrator!');
+      this.updateAdminUI();
+      this.save();
+    } else {
+      alert('Nieprawidłowe hasło.');
+    }
+  },
+
+  logout() {
+    clearInterval(this.gameLoopInterval);
+    clearInterval(this.marketInterval);
+    clearInterval(this.forumInterval);
+    localStorage.removeItem('lp_currentUser');
+    window.location.reload();
+  },
+
+  deleteAccount() {
+    if (confirm('Czy na pewno chcesz usunąć swoje konto? Tej operacji nie można cofnąć!')) {
+      const currentUsername = localStorage.getItem('lp_currentUser');
+      const users = this.getUsers().filter((entry) => entry.username !== currentUsername);
+      this.saveUsers(users);
+      this.logout();
+    }
+  },
+
+  formatCurrency(num, digits = 2) {
+    const lookup = [
+      { value: 1, symbol: '' },
+      { value: 1e3, symbol: ' tys.' },
+      { value: 1e6, symbol: ' mln' },
+      { value: 1e9, symbol: ' mld' },
+      { value: 1e12, symbol: ' bln' },
+      { value: 1e15, symbol: ' bld' },
+    ];
+    const item = [...lookup].reverse().find((entry) => Math.abs(num) >= entry.value);
+    if (item && item.value > 1) {
+      return `${num < 0 ? '-' : ''}$${Math.abs(num / item.value)
+        .toFixed(digits)
+        .replace(/\.0+$/, '')}${item.symbol}`;
+    }
+    return `${num < 0 ? '-' : ''}$${Math.abs(num).toLocaleString(undefined, {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: digits,
+    })}`;
+  },
+};
+
+DocumentReady(() => {
+  Game.init();
+  window.Game = Game;
+});
+
+function DocumentReady(callback) {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', callback, { once: true });
+  } else {
+    callback();
+  }
+}

--- a/docs/styles/liga.css
+++ b/docs/styles/liga.css
@@ -1,0 +1,737 @@
+/* --- ZMIENNE I RESETOWANIE --- */
+:root {
+  --bg-dark: #0a0e1b;
+  --panel-dark: #121729;
+  --panel-light: #1b213b;
+  --border-dark: rgba(255, 255, 255, 0.08);
+  --txt-dark: #e0e8ff;
+  --muted-dark: #8a99c8;
+  --acc1-dark: #6ea8ff;
+  --acc2-dark: #8ef0c0;
+  --good-dark: #3ad29f;
+  --bad-dark: #ff6b6b;
+
+  --bg-light: #f0f4f8;
+  --panel-light-theme: #ffffff;
+  --panel-light-theme-2: #f8fafd;
+  --border-light: #dfe7f0;
+  --txt-light: #1b213b;
+  --muted-light: #5a6789;
+  --acc1-light: #2a68d7;
+  --acc2-light: #1a9a6a;
+  --good-light: #1a9a6a;
+  --bad-light: #d94343;
+
+  --br: 18px;
+  --shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+}
+
+[data-theme='dark'] {
+  --bg: var(--bg-dark);
+  --panel: var(--panel-dark);
+  --panel-2: var(--panel-light);
+  --border: var(--border-dark);
+  --txt: var(--txt-dark);
+  --muted: var(--muted-dark);
+  --acc1: var(--acc1-dark);
+  --acc2: var(--acc2-dark);
+  --good: var(--good-dark);
+  --bad: var(--bad-dark);
+}
+
+[data-theme='light'] {
+  --bg: var(--bg-light);
+  --panel: var(--panel-light-theme);
+  --panel-2: var(--panel-light-theme-2);
+  --border: var(--border-light);
+  --txt: var(--txt-light);
+  --muted: var(--muted-light);
+  --acc1: var(--acc1-light);
+  --acc2: var(--acc2-light);
+  --good: var(--good-light);
+  --bad: var(--bad-light);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: 'Inter', sans-serif;
+  background-color: var(--bg);
+  color: var(--txt);
+  transition: background-color 0.3s, color 0.3s;
+  overflow: hidden;
+}
+
+body::before {
+  content: '';
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: url('https://images.unsplash.com/photo-1556761175-5973dc0f32e7?q=80&w=2832&auto=format&fit=crop')
+    no-repeat center center / cover;
+  opacity: 0.08;
+  z-index: -1;
+  transition: opacity 0.5s;
+}
+
+body[data-theme='light']::before {
+  opacity: 0.15;
+}
+
+.hidden {
+  display: none !important;
+}
+
+/* --- EKRAN LOGOWANIA I REJESTRACJI --- */
+#auth-screen {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  flex-direction: column;
+  text-align: center;
+  background: radial-gradient(circle, rgba(18, 23, 41, 0.8) 0%, rgba(10, 14, 27, 1) 100%);
+}
+
+.auth-title {
+  font-family: 'Nunito', sans-serif;
+  font-size: 4rem;
+  font-weight: 900;
+  letter-spacing: 2px;
+  color: #fff;
+  animation: fadeInGlow 3s ease-in-out forwards;
+  opacity: 0;
+}
+
+@keyframes fadeInGlow {
+  0% {
+    opacity: 0;
+    text-shadow: 0 0 5px rgba(255, 255, 255, 0);
+  }
+  50% {
+    opacity: 1;
+    text-shadow: 0 0 20px rgba(110, 168, 255, 0.5);
+  }
+  100% {
+    opacity: 1;
+    text-shadow: 0 0 10px rgba(110, 168, 255, 0.3);
+  }
+}
+
+.auth-container {
+  background: var(--panel-dark);
+  padding: 30px 40px;
+  border-radius: var(--br);
+  border: 1px solid var(--border-dark);
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.5);
+  width: 100%;
+  max-width: 400px;
+  margin-top: 20px;
+}
+
+.auth-container h2 {
+  margin: 0 0 20px 0;
+  font-family: 'Nunito', sans-serif;
+  color: var(--txt-dark);
+}
+
+.input-group {
+  margin-bottom: 15px;
+  text-align: left;
+}
+
+.input-group label {
+  display: block;
+  margin-bottom: 5px;
+  font-size: 14px;
+  color: var(--muted-dark);
+}
+
+.auth-input {
+  width: 100%;
+  padding: 12px;
+  border-radius: 10px;
+  border: 1px solid var(--border-dark);
+  background: var(--bg-dark);
+  color: var(--txt-dark);
+  font-family: 'Inter', sans-serif;
+  font-size: 16px;
+}
+
+.auth-btn {
+  width: 100%;
+  padding: 12px;
+  border: none;
+  border-radius: 10px;
+  background: linear-gradient(90deg, var(--acc1-dark), var(--acc2-dark));
+  color: #0a0e1b;
+  font-weight: 700;
+  font-size: 16px;
+  cursor: pointer;
+  margin-top: 10px;
+}
+
+#auth-toggle {
+  color: var(--acc1-dark);
+  cursor: pointer;
+  margin-top: 15px;
+  font-size: 14px;
+}
+
+#auth-error {
+  color: var(--bad-dark);
+  font-size: 14px;
+  margin-top: 10px;
+  min-height: 20px;
+}
+
+#auth-error-reg {
+  color: var(--bad-dark);
+  font-size: 14px;
+  margin-top: 10px;
+  min-height: 20px;
+}
+
+/* --- GŁÓWNY UKŁAD GRY --- */
+#game-container {
+  opacity: 0;
+  transition: opacity 0.5s ease-in-out;
+}
+
+.wrap {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  gap: 18px;
+  padding: 18px;
+  max-width: 1400px;
+  margin: 0 auto;
+  height: 100vh;
+}
+
+.sidebar {
+  position: sticky;
+  top: 18px;
+  height: calc(100vh - 36px);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  overflow-y: auto;
+  padding-right: 10px;
+}
+
+.card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--br);
+  box-shadow: var(--shadow);
+  transition: background-color 0.3s, border-color 0.3s;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 18px;
+  background: linear-gradient(90deg, rgba(110, 168, 255, 0.16), rgba(142, 240, 192, 0.12));
+}
+
+.brand h1 {
+  font-family: 'Nunito', sans-serif;
+  font-weight: 800;
+  font-size: 20px;
+  margin: 0;
+}
+
+.tag {
+  color: var(--muted);
+  font-size: 12px;
+  margin-top: 2px;
+}
+
+nav .btn {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  color: var(--txt);
+  text-decoration: none;
+  transition: all 0.2s;
+}
+
+nav .btn:hover {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: rgba(255, 255, 255, 0.08);
+}
+
+[data-theme='light'] nav .btn:hover {
+  background: #eef2f7;
+}
+
+nav .btn.active {
+  background: linear-gradient(180deg, rgba(110, 168, 255, 0.18), rgba(110, 168, 255, 0.08));
+  border-color: rgba(110, 168, 255, 0.3);
+  font-weight: 600;
+}
+
+nav .btn.locked {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* --- TOP BAR I PROFIL GRACZA --- */
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.kpi-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+  flex-grow: 1;
+}
+
+.kpi {
+  padding: 12px 16px;
+  border-radius: 14px;
+  background: var(--panel-2);
+  border: 1px solid var(--border);
+}
+
+.kpi h3 {
+  margin: 0;
+  font-size: 13px;
+  color: var(--muted);
+  font-weight: 600;
+}
+
+.kpi .val {
+  font-weight: 800;
+  font-size: 20px;
+  margin-top: 6px;
+  letter-spacing: 0.3px;
+}
+
+.player-card {
+  display: flex;
+  align-items: center;
+  gap: 15px;
+  padding: 8px 16px 8px 8px;
+  border-radius: 999px;
+  background: var(--panel-dark);
+  border: 1px solid var(--border);
+}
+
+.level-indicator {
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  border: 2px solid var(--acc1);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 16px;
+}
+
+.player-info {
+  text-align: left;
+}
+
+.player-info h4 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.player-info .level {
+  font-size: 12px;
+  color: var(--muted);
+  margin-top: 2px;
+}
+
+.xp-wrap {
+  grid-column: span 3;
+  padding: 12px;
+  background: var(--panel-2);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  margin-top: 12px;
+}
+
+.progress {
+  height: 12px;
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: 999px;
+  flex: 1;
+  position: relative;
+  overflow: hidden;
+}
+
+.progress > i {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, var(--acc1), var(--acc2));
+  transform-origin: left;
+  transform: scaleX(0);
+  transition: transform 0.3s;
+}
+
+/* --- OGÓLNE KOMPONENTY --- */
+.btn {
+  background: linear-gradient(90deg, var(--acc1), var(--acc2));
+  border: none;
+  color: #0a0e1b;
+  font-weight: 700;
+  padding: 10px 16px;
+  border-radius: 12px;
+  cursor: pointer;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+  transition: 0.15s all;
+}
+
+.btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.25);
+}
+
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  filter: grayscale(0.5);
+  transform: none;
+  box-shadow: none;
+}
+
+.btn-ghost {
+  background: var(--panel-2);
+  border: 1px solid var(--border);
+  color: var(--txt);
+  box-shadow: none;
+}
+
+.section h2 {
+  margin: 0 0 8px 0;
+  font-size: 22px;
+  font-weight: 800;
+  font-family: 'Nunito', sans-serif;
+}
+
+.section .sub {
+  margin: 0 0 16px 0;
+  color: var(--muted);
+  font-size: 14px;
+  max-width: 80ch;
+}
+
+.grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 18px;
+}
+
+/* --- IMPERIUM --- */
+#companies-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(380px, 1fr));
+  gap: 18px;
+}
+
+.company-card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--br);
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+}
+
+.company-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.company-card-header h4 {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 700;
+}
+
+.pill {
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: var(--panel-2);
+  border: 1px solid var(--border);
+  font-size: 12px;
+  white-space: nowrap;
+  font-weight: 600;
+}
+
+.company-stats {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+  font-size: 14px;
+}
+
+.mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-weight: 600;
+}
+
+/* --- UMYSŁ PRZEDSIĘBIORCY --- */
+.tree-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+}
+
+.tech-branch {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--br);
+  padding: 20px;
+}
+
+.tech-branch h3 {
+  margin: 0 0 15px 0;
+}
+
+.tech-item {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  background: var(--panel-2);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  margin-bottom: 12px;
+}
+
+/* --- GIEŁDA --- */
+.market-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 15px;
+}
+
+.stock {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 15px;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.price {
+  font-size: 22px;
+  font-weight: 800;
+}
+
+.trend.up {
+  color: var(--good);
+}
+
+.trend.down {
+  color: var(--bad);
+}
+
+.stock-input {
+  width: 100%;
+  padding: 8px;
+  border-radius: 8px;
+  background: var(--panel-2);
+  border: 1px solid var(--border);
+  color: var(--txt);
+}
+
+/* --- GŁOS RYNKU --- */
+.forum-container {
+  display: grid;
+  grid-template-columns: 1fr 350px;
+  gap: 18px;
+}
+
+.forum-feed-container {
+  background: var(--panel);
+  border-radius: var(--br);
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+}
+
+.forum-tabs {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 15px;
+}
+
+.forum-tab {
+  padding: 8px 15px;
+  border-radius: 10px;
+  cursor: pointer;
+  background: var(--panel-2);
+  border: none;
+  color: inherit;
+}
+
+.forum-tab.active {
+  background: var(--acc1);
+  color: #0a0e1b;
+  font-weight: 600;
+}
+
+.forum-feed {
+  flex-grow: 1;
+  overflow-y: auto;
+  max-height: 450px;
+}
+
+.post {
+  padding: 12px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.post:last-child {
+  border-bottom: none;
+}
+
+.post-header {
+  font-size: 12px;
+  color: var(--muted);
+  margin-bottom: 5px;
+}
+
+.post-header b {
+  color: var(--txt);
+}
+
+.post-form {
+  background: var(--panel);
+  border-radius: var(--br);
+  padding: 20px;
+}
+
+.post-form textarea {
+  width: 100%;
+  height: 120px;
+  background: var(--panel-2);
+  border: 1px solid var(--border);
+  color: var(--txt);
+  padding: 10px;
+  border-radius: 10px;
+}
+
+/* --- USTAWIENIA --- */
+.settings-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 18px;
+}
+
+.setting-card {
+  background: var(--panel);
+  border-radius: var(--br);
+  padding: 20px;
+}
+
+.setting-card h3 {
+  margin-top: 0;
+}
+
+.switch {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.switch input {
+  appearance: none;
+  width: 42px;
+  height: 24px;
+  border-radius: 999px;
+  background: var(--panel-2);
+  position: relative;
+  outline: none;
+  transition: 0.15s;
+  cursor: pointer;
+}
+
+.switch input:checked {
+  background: linear-gradient(90deg, var(--acc2), var(--acc1));
+}
+
+.switch input:before {
+  content: '';
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  background: #fff;
+  transition: 0.2s;
+}
+
+.switch input:checked:before {
+  left: 21px;
+}
+
+/* --- RESPONSYWNOŚĆ --- */
+@media (max-width: 980px) {
+  .wrap {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    position: relative;
+    top: 0;
+    height: auto;
+  }
+
+  .kpi-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .xp-wrap {
+    grid-column: span 2;
+  }
+
+  .tree-grid,
+  .settings-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .forum-container {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- add a standalone `Liga Przedsiębiorców` game page under `docs/` so it can be hosted statically
- extract the original inline styles and scripts into dedicated CSS/JS files while fixing state persistence, theme toggling, quest checks, and admin UI handling
- document the new page in the README for easier discovery

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68d8da16ee98833099b45ffbef4cae3a